### PR TITLE
introduce jacoco plugin again for collect jvm test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,5 @@ jobs:
       - run:
           command: |
             ./gradlew check
+            ./gradlew jacocoTestReport
+            bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
     <img alt="License: Apache License 2.0" src="https://img.shields.io/badge/License-Apache License 2.0-yellow.svg" target="_blank" />
   </a>
   <img alt="CircleCI" src="https://circleci.com/gh/doyaaaaaken/kotlin-csv/tree/master.svg?style=svg" />
+  <a href="https://codecov.io/gh/doyaaaaaken/kotlin-csv">
+    <img src="https://codecov.io/gh/doyaaaaaken/kotlin-csv/branch/master/graph/badge.svg" alt="codecov" />
+  </a>
   <a href="https://www.codefactor.io/repository/github/doyaaaaaken/kotlin-csv">
     <img src="https://www.codefactor.io/repository/github/doyaaaaaken/kotlin-csv/badge" alt="CodeFactor" />
   </a>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
+    java
     kotlin("multiplatform") version "1.3.50"
     id("org.jetbrains.dokka").version("0.9.18")
     `maven-publish`
     signing
+    jacoco
 }
 
 group = "com.github.doyaaaaaken"
@@ -134,4 +136,31 @@ publishing {
 
 signing {
     sign(publishing.publications)
+}
+
+/////////////////////////////////////////
+//         Jacoco setting              //
+/////////////////////////////////////////
+jacoco {
+    toolVersion = "0.8.5"
+}
+tasks.jacocoTestReport {
+    val coverageSourceDirs = arrayOf(
+            "commonMain/src",
+            "jvmMain/src"
+    )
+    val classFiles = File("${buildDir}/classes/kotlin/jvm/")
+            .walkBottomUp()
+            .toSet()
+    classDirectories.setFrom(classFiles)
+    sourceDirectories.setFrom(files(coverageSourceDirs))
+    additionalSourceDirs.setFrom(files(coverageSourceDirs))
+
+    executionData
+            .setFrom(files("${buildDir}/jacoco/jvmTest.exec"))
+
+    reports {
+        xml.isEnabled = true
+        html.isEnabled = false
+    }
 }


### PR DESCRIPTION
Jacoco plugin was introduced by #4 in past, but it removed because it was not supported by kotlin multiplatform project.

Introduce jacoco plugin again for collect only jvm test coverage.