### PR TITLE
Output last line terminator option for CsvWriter class

### DIFF
--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
@@ -7,10 +7,10 @@ package com.github.doyaaaaaken.kotlincsv.client
 sealed class CsvWriterState(val wroteFirstLine: Boolean, val wroteLastLineTerminator: Boolean)
 
 object DefaultState: CsvWriterState(wroteFirstLine = false, wroteLastLineTerminator =  false)
-object HasNotWroteLastLineTerminator: CsvWriterState(true, wroteLastLineTerminator = false)
-object HasWroteLastLineTerminator: CsvWriterState(true, wroteLastLineTerminator = true)
+object HasNotWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wroteLastLineTerminator = false)
+object HasWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wroteLastLineTerminator = true)
 
-class CsVWriterStateHandler {
+class CsvWriterStateHandler {
     private var state: CsvWriterState = DefaultState
 
     fun hasWroteFirstLine(): Boolean {
@@ -25,7 +25,7 @@ class CsVWriterStateHandler {
         state = HasWroteLastLineTerminator
     }
 
-    fun notWroteTerminatorState() {
+    fun notWroteLastLineTerminatorState() {
         state = HasNotWroteLastLineTerminator
     }
 }

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
@@ -4,12 +4,6 @@ package com.github.doyaaaaaken.kotlincsv.client
  * CSV writer state and handler
  * @author blacmko18
  */
-sealed class CsvWriterState(val wroteFirstLine: Boolean, val wroteLastLineTerminator: Boolean)
-
-object DefaultState: CsvWriterState(wroteFirstLine = false, wroteLastLineTerminator =  false)
-object HasNotWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wroteLastLineTerminator = false)
-object HasWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wroteLastLineTerminator = true)
-
 class CsvWriterStateHandler {
 
     internal sealed class CsvWriterState(val wroteFirstLine: Boolean, val wroteLineEndTerminator: Boolean) {

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
@@ -1,0 +1,31 @@
+package com.github.doyaaaaaken.kotlincsv.client
+
+/**
+ * CSV writer state and handler
+ * @author blacmko18
+ */
+sealed class CsvWriterState(val wroteFirstLine: Boolean, val wroteLastLineTerminator: Boolean)
+
+object DefaultState: CsvWriterState(wroteFirstLine = false, wroteLastLineTerminator =  false)
+object HasNotWroteLastLineTerminator: CsvWriterState(true, wroteLastLineTerminator = false)
+object HasWroteLastLineTerminator: CsvWriterState(true, wroteLastLineTerminator = true)
+
+class CsVWriterStateHandler {
+    private var state: CsvWriterState = DefaultState
+
+    fun hasWroteFirstLine(): Boolean {
+        return state.wroteFirstLine
+    }
+
+    fun hasWroteLastLineTerminator(): Boolean {
+        return state.wroteLastLineTerminator
+    }
+
+    fun wroteLastLineTerminatorState() {
+        state = HasWroteLastLineTerminator
+    }
+
+    fun notWroteTerminatorState() {
+        state = HasNotWroteLastLineTerminator
+    }
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterState.kt
@@ -11,21 +11,28 @@ object HasNotWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wrot
 object HasWroteLastLineTerminator: CsvWriterState(wroteFirstLine = true, wroteLastLineTerminator = true)
 
 class CsvWriterStateHandler {
-    private var state: CsvWriterState = DefaultState
+
+    internal sealed class CsvWriterState(val wroteFirstLine: Boolean, val wroteLineEndTerminator: Boolean) {
+        object InitialState: CsvWriterState(wroteFirstLine = false, wroteLineEndTerminator =  false)
+        object HasNotWroteLineEndTerminator: CsvWriterState(wroteFirstLine = true, wroteLineEndTerminator = false)
+        object HasWroteLineEndTerminator: CsvWriterState(wroteFirstLine = true, wroteLineEndTerminator = true)
+    }
+
+    private var state: CsvWriterState = CsvWriterState.InitialState
 
     fun hasWroteFirstLine(): Boolean {
         return state.wroteFirstLine
     }
 
-    fun hasWroteLastLineTerminator(): Boolean {
-        return state.wroteLastLineTerminator
+    fun hasWroteLineEndTerminator(): Boolean {
+        return state.wroteLineEndTerminator
     }
 
-    fun wroteLastLineTerminatorState() {
-        state = HasWroteLastLineTerminator
+    fun wroteLineEndTerminatorState() {
+        state = CsvWriterState.HasWroteLineEndTerminator
     }
 
-    fun notWroteLastLineTerminatorState() {
-        state = HasNotWroteLastLineTerminator
+    fun notWroteLineEndTerminatorState() {
+        state = CsvWriterState.HasNotWroteLineEndTerminator
     }
 }

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvWriterContext.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvWriterContext.kt
@@ -15,6 +15,7 @@ interface ICsvWriterContext {
     val nullCode: String
     val lineTerminator: String
     val quote: CsvWriteQuoteContext
+    val outputLastLineTerminator: Boolean
 }
 
 /**
@@ -29,6 +30,7 @@ class CsvWriterContext : ICsvWriterContext {
     override var nullCode: String = ""
     override var lineTerminator: String = "\r\n"
     override val quote: CsvWriteQuoteContext = CsvWriteQuoteContext()
+    override var outputLastLineTerminator = true
 
     fun quote(init: CsvWriteQuoteContext.() -> Unit) {
         quote.init()

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -20,7 +20,7 @@ class CsvFileWriter internal constructor(
     /**
      * state handling to write terminator for next line
      */
-    private val stateHandler = CsVWriterStateHandler()
+    private val stateHandler = CsvWriterStateHandler()
 
 
     /**
@@ -95,7 +95,7 @@ class CsvFileWriter internal constructor(
             writeTerminator()
             stateHandler.wroteLastLineTerminatorState()
         } else {
-            stateHandler.notWroteTerminatorState()
+            stateHandler.notWroteLastLineTerminatorState()
         }
     }
 

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -58,10 +58,13 @@ class CsvFileWriter internal constructor(
      * write rows from Sequence
      */
     override fun writeRows(rows: Sequence<List<Any?>>) {
-        val size = rows.count()
+        val itr = rows.iterator()
+
         willWritePreTerminator()
-        rows.forEachIndexed {index, list ->  writeNext(list)
-            if (index < size-1) {
+        rows.forEach {
+            itr.next()
+            writeNext(it)
+            if (itr.hasNext()) {
                 writeTerminator()
             }
         }
@@ -93,9 +96,9 @@ class CsvFileWriter internal constructor(
     private fun willWriteEndTerminator() {
         if (ctx.outputLastLineTerminator) {
             writeTerminator()
-            stateHandler.wroteLastLineTerminatorState()
+            stateHandler.wroteLineEndTerminatorState()
         } else {
-            stateHandler.notWroteLastLineTerminatorState()
+            stateHandler.notWroteLineEndTerminatorState()
         }
     }
 
@@ -105,7 +108,7 @@ class CsvFileWriter internal constructor(
      *  2. state is set to has not wrote last line terminator
      */
     private fun willWritePreTerminator() {
-        if (stateHandler.hasWroteFirstLine() && !stateHandler.hasWroteLastLineTerminator()) {
+        if (stateHandler.hasWroteFirstLine() && !stateHandler.hasWroteLineEndTerminator()) {
             writeTerminator()
         }
     }
@@ -115,7 +118,7 @@ class CsvFileWriter internal constructor(
      */
     private fun writeTerminator() {
         writer.print(ctx.lineTerminator)
-        stateHandler.wroteLastLineTerminatorState()
+        stateHandler.wroteLineEndTerminatorState()
     }
 
     private fun attachQuote(field: String): String {

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
@@ -234,7 +234,6 @@ class CsvWriterTest : WordSpec() {
                     writeRows(listOf(row2, row3))
                     writeRow(row4)
                     writeRows(listOf(row5, row6))
-
                 }
                 val actual = readTestFile()
                 actual shouldBe expected

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
@@ -194,6 +194,51 @@ class CsvWriterTest : WordSpec() {
                 val actual = readTestFile()
                 actual shouldBe expected
             }
+            "write simple csv with disabled last line terminator with custom terminator" {
+                val row1 = listOf("a", "b")
+                val row2 = listOf("c", "d")
+                val expected = "a,b\nc,d"
+                csvWriter{
+                    lineTerminator = "\n"
+                    outputLastLineTerminator = false
+                }.open(File(testFileName)) {
+                    writeRows(listOf(row1, row2))
+                }
+                val actual = readTestFile()
+                actual shouldBe expected
+            }
+            "write simple csv with disabled last line terminator" {
+                val row1 = listOf("a", "b")
+                val row2 = listOf("c", "d")
+                val expected = "a,b\r\nc,d"
+                csvWriter{
+                    outputLastLineTerminator = false
+                }.open(File(testFileName)) {
+                    writeRows(listOf(row1, row2))
+                }
+                val actual = readTestFile()
+                actual shouldBe expected
+            }
+            "write simple csv with disabled last line terminator multiple writes" {
+                val row1 = listOf("a", "b")
+                val row2 = listOf("c", "d")
+                val row3 = listOf("e", "f")
+                val row4 = listOf("g", "h")
+                val row5 = listOf("1", "2")
+                val row6 = listOf("3", "4")
+                val expected = "a,b\r\nc,d\r\ne,f\r\ng,h\r\n1,2\r\n3,4"
+                csvWriter{
+                    outputLastLineTerminator = false
+                }.open(File(testFileName)) {
+                    writeRow(row1)
+                    writeRows(listOf(row2, row3))
+                    writeRow(row4)
+                    writeRows(listOf(row5, row6))
+
+                }
+                val actual = readTestFile()
+                actual shouldBe expected
+            }
         }
     }
 }

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvWriterTest.kt
@@ -207,6 +207,19 @@ class CsvWriterTest : WordSpec() {
                 val actual = readTestFile()
                 actual shouldBe expected
             }
+            "write simple csv with enabled last line and custom terminator" {
+                val row1 = listOf("a", "b")
+                val row2 = listOf("c", "d")
+                val expected = "a,b\nc,d\n"
+                csvWriter{
+                    lineTerminator = "\n"
+                    outputLastLineTerminator = true
+                }.open(File(testFileName)) {
+                    writeRows(listOf(row1, row2))
+                }
+                val actual = readTestFile()
+                actual shouldBe expected
+            }
             "write simple csv with disabled last line terminator" {
                 val row1 = listOf("a", "b")
                 val row2 = listOf("c", "d")

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/CsvWriterDslTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/CsvWriterDslTest.kt
@@ -20,6 +20,7 @@ class CsvWriterDslTest : StringSpec({
             delimiter = '\t'
             nullCode = "NULL"
             lineTerminator = "\n"
+            outputLastLineTerminator = false
             quote {
                 char = '\''
                 mode = WriteQuoteMode.ALL
@@ -29,6 +30,7 @@ class CsvWriterDslTest : StringSpec({
         writer.delimiter shouldBe '\t'
         writer.nullCode shouldBe "NULL"
         writer.lineTerminator shouldBe "\n"
+        writer.outputLastLineTerminator shouldBe false
         writer.quote.char shouldBe '\''
         writer.quote.mode = WriteQuoteMode.ALL
     }


### PR DESCRIPTION
Issue #18 
 - Added Option to CsvWriterContext
 - Added State and State Handler in CsvWriter
     * this due to in CsvWriter open method it is allowed to write in multiple ways and order of:
         1. writeRow
         2. writeRows
- Added Test