### PR TITLE
Added writing a row from variable number of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ val row2 = listOf("d", "e", "f")
 csvWriter().open("test.csv") { 
     writeRow(row1)
     writeRow(row2)
+    writeRow("g", "h", "i")
     writeRows(listOf(row1, row2))
 }
 ```

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/ICsvFileWriter.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/ICsvFileWriter.kt
@@ -3,7 +3,7 @@ package com.github.doyaaaaaken.kotlincsv.client
 interface ICsvFileWriter {
     fun writeRow(row: List<Any?>)
 
-    fun writeRow(vararg entry: Any)
+    fun writeRow(vararg entry: Any?)
 
     fun writeRows(rows: List<List<Any?>>)
 

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/ICsvFileWriter.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/ICsvFileWriter.kt
@@ -3,6 +3,8 @@ package com.github.doyaaaaaken.kotlincsv.client
 interface ICsvFileWriter {
     fun writeRow(row: List<Any?>)
 
+    fun writeRow(vararg entry: Any)
+
     fun writeRows(rows: List<List<Any?>>)
 
     fun writeRows(rows: Sequence<List<Any?>>)

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -37,6 +37,13 @@ class CsvFileWriter internal constructor(
     }
 
     /**
+     * write one row
+     */
+    override fun writeRow(vararg entry: Any) {
+        writeRow(entry.toList())
+    }
+
+    /**
      * write rows
      */
     override fun writeRows(rows: List<List<Any?>>) {

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -39,7 +39,7 @@ class CsvFileWriter internal constructor(
     /**
      * write one row
      */
-    override fun writeRow(vararg entry: Any) {
+    override fun writeRow(vararg entry: Any?) {
         writeRow(entry.toList())
     }
 

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
@@ -51,6 +51,24 @@ class CsvFileWriterTest : WordSpec() {
                 val actual = readTestFile()
                 actual shouldBe expected
             }
+            "write row from variable arguments" {
+
+                val date1 = LocalDate.of(2019, 8, 19)
+                val date2 = LocalDateTime.of(2020, 9, 20, 14, 32, 21)
+
+                val expected = "a,b,c\r\n"+
+                    "d,e,f\r\n"+
+                    "1,2,3\r\n"+
+                    "2019-08-19,2020-09-20T14:32:21\r\n"
+                csvWriter().open(testFileName) {
+                    writeRow("a", "b", "c")
+                    writeRow("d", "e", "f")
+                    writeRow(1,2,3)
+                    writeRow(date1, date2)
+                }
+                val actual = readTestFile()
+                actual shouldBe expected
+            }
         }
         "writeAll method" should {
             "write Sequence data" {


### PR DESCRIPTION
I think to be able to write a variable number of arguments is nice also without creating a list before hand.

example:
```kotlin
csvWriter().open(testFileName) {
    writeRow("a", "b", "c")
    writeRow("d", "e", "f")
    writeRow(1,2,3)
    writeRow(date1, date2, date3)
}
```
Although Kotlin already supports a variable argument in instantiating a  list with initial values, I think this one will be cleaner and less boiler plate on the user end.