### PR TITLE
In parser, use StringBuilder.clear() instead of...

### DIFF
--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/parser/ParseStateMachine.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/parser/ParseStateMachine.kt
@@ -170,7 +170,7 @@ internal class ParseStateMachine(
 
     private fun flushField() {
         fields.add(field.toString())
-        field = StringBuilder()
+        field.clear()
     }
 }
 


### PR DESCRIPTION
...allocating new StringBuilder

This reuses the StringBuilder's internal buffer rather than reallocating for each field.
On my local benchmark this improves performance of reading 48MB file by about 20%.