### PR TITLE
Add read support for Javascript.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    kotlin("multiplatform") version "1.4.31"
+    kotlin("multiplatform") version "1.5.21"
     id("org.jetbrains.dokka").version("0.9.18")
     `maven-publish`
     signing
@@ -38,7 +38,7 @@ kotlin {
             artifact(dokkaJar)
         }
     }
-    js {
+    js(BOTH) {
         browser {
         }
         nodejs {
@@ -47,7 +47,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
+                implementation("io.github.microutils:kotlin-logging:2.0.10")
             }
         }
         val commonTest by getting {
@@ -59,20 +59,18 @@ kotlin {
 
         jvm().compilations["main"].defaultSourceSet {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-                implementation("io.github.microutils:kotlin-logging:1.7.9")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
+                implementation("io.github.microutils:kotlin-logging:2.0.10")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
             }
         }
         jvm().compilations["test"].defaultSourceSet {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
                 implementation("io.kotest:kotest-runner-junit5-jvm:4.4.1")
             }
         }
         js().compilations["main"].defaultSourceSet {
             dependencies {
-                implementation(kotlin("stdlib-js"))
             }
         }
         js().compilations["test"].defaultSourceSet {

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/BufferedLineReader.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/BufferedLineReader.kt
@@ -1,14 +1,11 @@
 package com.github.doyaaaaaken.kotlincsv.client
 
-import java.io.BufferedReader
-import java.io.Closeable
-
 /**
  * buffered reader which can read line with line terminator
  */
 internal class BufferedLineReader(
-        private val br: BufferedReader
-) : Closeable {
+        private val br: Reader
+) {
 
     fun readLineWithTerminator(): String? {
         val sb = StringBuilder()
@@ -46,7 +43,7 @@ internal class BufferedLineReader(
         return sb.toString()
     }
 
-    override fun close() {
+    fun close() {
         br.close()
     }
 }

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
@@ -5,8 +5,6 @@ import com.github.doyaaaaaken.kotlincsv.parser.CsvParser
 import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
 import com.github.doyaaaaaken.kotlincsv.util.MalformedCSVException
 import mu.KotlinLogging
-import java.io.BufferedReader
-import java.io.Closeable
 
 /**
  * CSV Reader class, which controls file I/O flow.
@@ -15,8 +13,8 @@ import java.io.Closeable
  */
 class CsvFileReader internal constructor(
         private val ctx: CsvReaderContext,
-        reader: BufferedReader
-) : Closeable {
+        reader: Reader
+) {
 
     private val logger = KotlinLogging.logger {  }
     private val reader = BufferedLineReader(reader)
@@ -46,7 +44,7 @@ class CsvFileReader internal constructor(
             if (fieldsNumInRow == null) fieldsNumInRow = row.size
             if (fieldsNumInRow != row.size) {
                 if (ctx.skipMissMatchedRow) {
-                    logger.info("skip miss matched row. [csv row num = ${idx + 1}, fields num = ${row.size}, fields num of first row = $fieldsNumInRow]")
+                    logger.info{"skip miss matched row. [csv row num = ${idx + 1}, fields num = ${row.size}, fields num of first row = $fieldsNumInRow]"}
                     null
                 } else {
                     throw CSVFieldNumDifferentException(requireNotNull(fieldsNumInRow), row.size, idx + 1)
@@ -67,7 +65,7 @@ class CsvFileReader internal constructor(
         return readAllAsSequence(headers.size).map { fields -> headers.zip(fields).toMap() }
     }
 
-    override fun close() {
+    fun close() {
         reader.close()
     }
 

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/Reader.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/Reader.kt
@@ -1,0 +1,62 @@
+package com.github.doyaaaaaken.kotlincsv.client
+
+internal interface Reader {
+    /**
+     * Reads a single character.
+     * Returns: The character read, as an integer in the range 0 to 65535 (0x00-0xffff), or -1 if the end of the stream has been reached
+     */
+    fun read(): Int
+
+    /**
+     * Marks the present position in the stream.  Subsequent calls to reset()
+     * will attempt to reposition the stream to this point.
+     *
+     * @param readAheadLimit   Limit on the number of characters that may be
+     *                         read while still preserving the mark. An attempt
+     *                         to reset the stream after reading characters
+     *                         up to this limit or beyond may fail.
+     *                         A limit value larger than the size of the input
+     *                         buffer will cause a new buffer to be allocated
+     *                         whose size is no smaller than limit.
+     *                         Therefore large values should be used with care.
+     *
+     * @exception  IllegalArgumentException  If {@code readAheadLimit < 0}
+     */
+    fun mark(readAheadLimit: Int): Unit
+
+    /**
+     * Resets the stream to the most recent mark.
+     */
+    fun reset(): Unit
+
+
+    fun close()
+}
+
+/**
+ * Multiplatform implementation of the Reader interface that uses a String as the backing
+ * data source.
+ */
+internal class StringReaderImpl(private val data: String) : Reader {
+    private var nextChar = 0
+    private var mark = -1
+
+    override fun read(): Int {
+        return if(nextChar == data.length){
+            -1
+        }else {
+            data[nextChar++].code
+        }
+    }
+
+    override fun mark(readAheadLimit: Int) {
+        mark = nextChar
+    }
+
+    override fun reset() {
+        nextChar = mark
+    }
+
+    override fun close() {
+    }
+}

--- a/src/jsMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
+++ b/src/jsMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
@@ -9,20 +9,20 @@ import com.github.doyaaaaaken.kotlincsv.dsl.context.ICsvReaderContext
  * @author doyaaaaaken
  */
 actual class CsvReader actual constructor(
-        private val ctx: CsvReaderContext
+    private val ctx: CsvReaderContext
 ) : ICsvReaderContext by ctx {
 
     /**
      * read csv data as String, and convert into List<List<String>>
      */
     actual fun readAll(data: String): List<List<String>> {
-        TODO("not implemented")
+        return CsvFileReader(ctx, StringReaderImpl(data)).readAllAsSequence().toList()
     }
 
     /**
      * read csv data with header, and convert into List<Map<String, String>>
      */
     actual fun readAllWithHeader(data: String): List<Map<String, String>> {
-        TODO("not implemented")
+        return CsvFileReader(ctx, StringReaderImpl(data)).readAllWithHeaderAsSequence().toList()
     }
 }

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/Reader.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/Reader.kt
@@ -1,0 +1,24 @@
+package com.github.doyaaaaaken.kotlincsv.client
+
+import java.io.InputStream
+import java.nio.charset.Charset
+
+class ReaderJvmImpl(private val reader: java.io.BufferedReader): Reader {
+    override fun read(): Int {
+        return reader.read()
+    }
+
+    override fun mark(readAheadLimit: Int) {
+        reader.mark(readAheadLimit)
+    }
+
+    override fun reset() {
+        reader.reset()
+    }
+
+    override fun close() {
+        reader.close()
+    }
+}
+
+internal fun InputStream.bufferedReader(charset: Charset = Charsets.UTF_8): Reader = ReaderJvmImpl(reader(charset).buffered())

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
@@ -1,0 +1,156 @@
+package com.github.doyaaaaaken.kotlincsv.client
+
+import com.github.doyaaaaaken.kotlincsv.dsl.context.CsvReaderContext
+import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
+import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
+import com.github.doyaaaaaken.kotlincsv.util.CSVParseFormatException
+import com.github.doyaaaaaken.kotlincsv.util.Const
+import com.github.doyaaaaaken.kotlincsv.util.MalformedCSVException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
+
+class StringReaderTest : WordSpec({
+    "readAll method (with String argument)" should {
+        "read simple csv" {
+            val result = readAll(
+                """a,b,c
+                        |d,e,f
+                    """.trimMargin()
+            )
+            result shouldBe listOf(listOf("a", "b", "c"), listOf("d", "e", "f"))
+        }
+        "read csv with line separater" {
+            val result = readAll(
+                """a,b,c,"x","y
+                            | hoge"
+                        |d,e,f,g,h
+                    """.trimMargin()
+            )
+            result shouldBe listOf(listOf("a", "b", "c", "x", """y
+                    | hoge""".trimMargin()), listOf("d", "e", "f", "g", "h"))
+        }
+        "get failed rowNum and colIndex when exception happened on parsing CSV" {
+            val ex1 = shouldThrow<CSVParseFormatException> {
+                readAll("a,\"\"failed")
+            }
+            ex1.rowNum shouldBe 1
+            ex1.colIndex shouldBe 4
+            ex1.char shouldBe 'f'
+
+            val ex2 = shouldThrow<CSVParseFormatException> {
+                readAll("a,b\nc,\"\"failed")
+            }
+
+            ex2.rowNum shouldBe 2
+            ex2.colIndex shouldBe 4
+            ex2.char shouldBe 'f'
+
+            val ex3 = shouldThrow<CSVParseFormatException> {
+                readAll("a,\"b\nb\"\nc,\"\"failed")
+            }
+
+            ex3.rowNum shouldBe 3
+            ex3.colIndex shouldBe 4
+            ex3.char shouldBe 'f'
+        }
+    }
+
+    "readAll method" should {
+        "read simple csv" {
+            val result = readAll(readTestDataFile("simple.csv"))
+            result shouldBe listOf(listOf("a", "b", "c"), listOf("d", "e", "f"))
+        }
+        "read csv with empty field" {
+            val result = readAll(readTestDataFile("empty-fields.csv"))
+            result shouldBe listOf(listOf("a", "", "b", "", "c", ""), listOf("d", "", "e", "", "f", ""))
+        }
+        "read csv with escaped field" {
+            val result = readAll(readTestDataFile("escape.csv"))
+            result shouldBe listOf(listOf("a", "b", "c"), listOf("d", "\"e", "f"))
+        }
+        "read csv with line breaks enclosed in double quotes" {
+            val result = readAll(readTestDataFile("line-breaks.csv"))
+            result shouldBe listOf(listOf("a", "b\r\nb", "c"), listOf("\r\nd", "e", "f"))
+        }
+        //refs https://github.com/tototoshi/scala-csv/issues/22
+        "read csv with \u2028 field" {
+            val result = readAll(readTestDataFile("unicode2028.csv"))
+            result shouldBe listOf(listOf("\u2028"))
+        }
+        "throw exception when reading malformed csv" {
+            shouldThrow<MalformedCSVException> {
+                readAll(readTestDataFile("malformed.csv"))
+            }
+        }
+        "throw exception when reading csv with different fields num on each row" {
+            val ex = shouldThrow<CSVFieldNumDifferentException> {
+                readAll(readTestDataFile("different-fields-num.csv"))
+            }
+            ex.fieldNum shouldBe 3
+            ex.fieldNumOnFailedRow shouldBe 2
+            ex.csvRowNum shouldBe 2
+        }
+    }
+
+    "readAllWithHeader method" should {
+        val expected = listOf(
+            mapOf("h1" to "a", "h2" to "b", "h3" to "c"),
+            mapOf("h1" to "d", "h2" to "e", "h3" to "f")
+        )
+
+        "read simple csv file" {
+            val file = readTestDataFile("with-header.csv")
+            val result = readAllWithHeader(file)
+            result shouldBe expected
+        }
+
+        "read from String" {
+            val data = """h1,h2,h3
+                    |a,b,c
+                    |d,e,f
+                """.trimMargin()
+            val result = readAllWithHeader(data)
+            result shouldBe expected
+        }
+
+        "read from String containing line break" {
+            val data = """h1,"h
+                    |2",h3
+                    |a,b,c
+                """.trimMargin()
+            val result = readAllWithHeader(data)
+            val h2 = """h
+                    |2""".trimMargin()
+            result shouldBe listOf(mapOf("h1" to "a", h2 to "b", "h3" to "c"))
+        }
+        "number of fields in a row has to be based on the header #82" {
+            val data = "1,2,3\na,b\nx,y,z"
+
+            val exception = shouldThrow<CSVFieldNumDifferentException> {
+                readAllWithHeader(data)
+            }
+            exception.fieldNum shouldBe 3
+        }
+    }
+})
+
+private fun readTestDataFile(fileName: String): String {
+    return java.io.File("src/jvmTest/resources/testdata/csv/$fileName").readText()
+}
+
+/**
+ * read csv data as String, and convert into List<List<String>>
+ */
+private fun readAll(data: String): List<List<String>> {
+    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data)).readAllAsSequence().toList()
+}
+
+/**
+ * read csv data with header, and convert into List<Map<String, String>>
+ */
+private fun readAllWithHeader(data: String): List<Map<String, String>> {
+    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data)).readAllWithHeaderAsSequence().toList()
+}

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
@@ -73,7 +73,7 @@ class StringReaderTest : WordSpec({
         }
         "read csv with line breaks enclosed in double quotes" {
             val result = readAll(readTestDataFile("line-breaks.csv"))
-            result shouldBe listOf(listOf("a", "b\r\nb", "c"), listOf("\r\nd", "e", "f"))
+            result shouldBe listOf(listOf("a", "b\nb", "c"), listOf("\nd", "e", "f"))
         }
         //refs https://github.com/tototoshi/scala-csv/issues/22
         "read csv with \u2028 field" {


### PR DESCRIPTION
Added support for parsing CSVs on the Javascript platform from a provided input String. This could be moved to common and used for any target platform but the expect/actual mechanism would also need to be reworked.