### PR TITLE
Remove external log library

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,17 +165,18 @@ val tsvReader = csvReader {
 }
 ```
 
-| Option | default value | description                         |
-|------------|---------------|-------------------------------------|
-| charset |`UTF-8`| Charset encoding. The value must be supported by [java.nio.charset.Charset](https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html). |
-| quoteChar | `"` | Character used to quote fields. |
-| delimiter | `,` | Character used as delimiter between each field.<br />Use `"\t"` if reading TSV file. |
-| escapeChar | `"` | Character to escape quote inside field string.<br />Normally, you don't have to change this option.<br />See detail comment on [ICsvReaderContext](src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt). |
-| skipEmptyLine | `false` | Whether to skip or error out on empty lines. |
-| autoRenameDuplicateHeaders | `false` | Whether to auto rename duplicate headers or throw an exception. |
-| ~~skipMissMatchedRow~~ | `false` | Deprecated. Replace with appropriate values in `excessFieldsRowBehaviour` and `insufficientFieldsRowBehaviour`, e.g. both set to `IGNORE`. ~~Whether to skip an invalid row. If `ignoreExcessCols` is true, only rows with less than the expected number of columns will be skipped.~~ |
-| excessFieldsRowBehaviour | `ERROR` | Behaviour to use when a row has more fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `TRIM` (remove the excess fields at the end of the row to match the expected number of fields). |
-| insufficientFieldsRowBehaviour | `ERROR` | Behaviour to use when a row has fewer fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row). |
+| Option                         | default value | description                                                                                                                                                                                                                                                                            |
+|--------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| logger                         | _no-op_       | Logger instance for logging debug information at runtime.                                                                                                                                                                                                                              |
+| charset                        | `UTF-8`       | Charset encoding. The value must be supported by [java.nio.charset.Charset](https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html).                                                                                                                                  |
+| quoteChar                      | `"`           | Character used to quote fields.                                                                                                                                                                                                                                                        |
+| delimiter                      | `,`           | Character used as delimiter between each field.<br />Use `"\t"` if reading TSV file.                                                                                                                                                                                                   |
+| escapeChar                     | `"`           | Character to escape quote inside field string.<br />Normally, you don't have to change this option.<br />See detail comment on [ICsvReaderContext](src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt).                                            |
+| skipEmptyLine                  | `false`       | Whether to skip or error out on empty lines.                                                                                                                                                                                                                                           |
+| autoRenameDuplicateHeaders     | `false`       | Whether to auto rename duplicate headers or throw an exception.                                                                                                                                                                                                                        |
+| ~~skipMissMatchedRow~~         | `false`       | Deprecated. Replace with appropriate values in `excessFieldsRowBehaviour` and `insufficientFieldsRowBehaviour`, e.g. both set to `IGNORE`. ~~Whether to skip an invalid row. If `ignoreExcessCols` is true, only rows with less than the expected number of columns will be skipped.~~ |
+| excessFieldsRowBehaviour       | `ERROR`       | Behaviour to use when a row has more fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `TRIM` (remove the excess fields at the end of the row to match the expected number of fields).                                                                     |
+| insufficientFieldsRowBehaviour | `ERROR`       | Behaviour to use when a row has fewer fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row).                                                                                                                                                                      |
 
 ### CSV Write examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,11 +45,7 @@ kotlin {
         }
     }
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation("io.github.microutils:kotlin-logging:2.0.11")
-            }
-        }
+        val commonMain by getting
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
@@ -7,7 +7,6 @@ import com.github.doyaaaaaken.kotlincsv.parser.CsvParser
 import com.github.doyaaaaaken.kotlincsv.util.CSVAutoRenameFailedException
 import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
 import com.github.doyaaaaaken.kotlincsv.util.logger.Logger
-import com.github.doyaaaaaken.kotlincsv.util.logger.LoggerNop
 import com.github.doyaaaaaken.kotlincsv.util.MalformedCSVException
 
 /**

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileReader.kt
@@ -6,8 +6,9 @@ import com.github.doyaaaaaken.kotlincsv.dsl.context.InsufficientFieldsRowBehavio
 import com.github.doyaaaaaken.kotlincsv.parser.CsvParser
 import com.github.doyaaaaaken.kotlincsv.util.CSVAutoRenameFailedException
 import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
+import com.github.doyaaaaaken.kotlincsv.util.logger.Logger
+import com.github.doyaaaaaken.kotlincsv.util.logger.LoggerNop
 import com.github.doyaaaaaken.kotlincsv.util.MalformedCSVException
-import mu.KotlinLogging
 
 /**
  * CSV Reader class, which controls file I/O flow.
@@ -16,10 +17,10 @@ import mu.KotlinLogging
  */
 class CsvFileReader internal constructor(
     private val ctx: CsvReaderContext,
-    reader: Reader
+    reader: Reader,
+    private val logger: Logger,
 ) {
 
-    private val logger = KotlinLogging.logger { }
     private val reader = BufferedLineReader(reader)
     private var rowNum = 0L
 

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
@@ -13,6 +13,10 @@ import com.github.doyaaaaaken.kotlincsv.util.logger.LoggerNop
 @CsvDslMarker
 interface ICsvReaderContext {
 
+    /**
+     * Logger instance for logging debug statements.
+     * Default instance does not log anything.
+     */
     val logger: Logger
 
     /**

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
@@ -2,6 +2,8 @@ package com.github.doyaaaaaken.kotlincsv.dsl.context
 
 import com.github.doyaaaaaken.kotlincsv.util.Const
 import com.github.doyaaaaaken.kotlincsv.util.CsvDslMarker
+import com.github.doyaaaaaken.kotlincsv.util.logger.Logger
+import com.github.doyaaaaaken.kotlincsv.util.logger.LoggerNop
 
 /**
  * Interface for CSV Reader settings
@@ -10,6 +12,9 @@ import com.github.doyaaaaaken.kotlincsv.util.CsvDslMarker
  */
 @CsvDslMarker
 interface ICsvReaderContext {
+
+    val logger: Logger
+
     /**
      * Charset encoding
      *
@@ -119,6 +124,7 @@ enum class ExcessFieldsRowBehaviour {
  */
 @CsvDslMarker
 class CsvReaderContext : ICsvReaderContext {
+    override var logger: Logger = LoggerNop
     override var charset = Const.defaultCharset
     override var quoteChar: Char = '"'
     override var delimiter: Char = ','

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/Logger.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/Logger.kt
@@ -1,0 +1,5 @@
+package com.github.doyaaaaaken.kotlincsv.util.logger
+
+interface Logger {
+    fun info(message: () -> Any?)
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/Logger.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/Logger.kt
@@ -1,5 +1,10 @@
 package com.github.doyaaaaaken.kotlincsv.util.logger
 
+/**
+ * Logger interface for logging debug statements at runtime.
+ * Library consumers may provide implementations suiting their needs.
+ * @see [com.github.doyaaaaaken.kotlincsv.dsl.context.ICsvReaderContext.logger]
+ */
 interface Logger {
     fun info(message: () -> Any?)
 }

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/LoggerNop.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/LoggerNop.kt
@@ -1,0 +1,5 @@
+package com.github.doyaaaaaken.kotlincsv.util.logger
+
+internal object LoggerNop : Logger {
+    override fun info(message: () -> Any?) = Unit
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/LoggerNop.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/util/logger/LoggerNop.kt
@@ -1,5 +1,8 @@
 package com.github.doyaaaaaken.kotlincsv.util.logger
 
+/**
+ * Internal no-operation logger implementation, which does not log anything.
+ */
 internal object LoggerNop : Logger {
     override fun info(message: () -> Any?) = Unit
 }

--- a/src/jsMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
+++ b/src/jsMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
@@ -16,13 +16,13 @@ actual class CsvReader actual constructor(
      * read csv data as String, and convert into List<List<String>>
      */
     actual fun readAll(data: String): List<List<String>> {
-        return CsvFileReader(ctx, StringReaderImpl(data)).readAllAsSequence().toList()
+        return CsvFileReader(ctx, StringReaderImpl(data), logger).readAllAsSequence().toList()
     }
 
     /**
      * read csv data with header, and convert into List<Map<String, String>>
      */
     actual fun readAllWithHeader(data: String): List<Map<String, String>> {
-        return CsvFileReader(ctx, StringReaderImpl(data)).readAllWithHeaderAsSequence().toList()
+        return CsvFileReader(ctx, StringReaderImpl(data), logger).readAllWithHeaderAsSequence().toList()
     }
 }

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReader.kt
@@ -172,14 +172,14 @@ actual class CsvReader actual constructor(
     }
 
     private fun <T> open(br: Reader, doRead: CsvFileReader.() -> T): T {
-        val reader = CsvFileReader(ctx, br)
+        val reader = CsvFileReader(ctx, br, logger)
         return reader.use {
             reader.doRead()
         }
     }
 
     private suspend fun <T> openAsync(br: Reader, doRead: suspend CsvFileReader.() -> T): T {
-        val reader = CsvFileReader(ctx, br)
+        val reader = CsvFileReader(ctx, br, logger)
         return reader.use {
             reader.doRead()
         }

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/StringReaderTest.kt
@@ -4,6 +4,7 @@ import com.github.doyaaaaaken.kotlincsv.dsl.context.CsvReaderContext
 import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
 import com.github.doyaaaaaken.kotlincsv.util.CSVParseFormatException
 import com.github.doyaaaaaken.kotlincsv.util.MalformedCSVException
+import com.github.doyaaaaaken.kotlincsv.util.logger.LoggerNop
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -145,12 +146,12 @@ private fun readTestDataFile(fileName: String): String {
  * read csv data as String, and convert into List<List<String>>
  */
 private fun readAll(data: String): List<List<String>> {
-    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data)).readAllAsSequence().toList()
+    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data), LoggerNop).readAllAsSequence().toList()
 }
 
 /**
  * read csv data with header, and convert into List<Map<String, String>>
  */
 private fun readAllWithHeader(data: String): List<Map<String, String>> {
-    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data)).readAllWithHeaderAsSequence().toList()
+    return CsvFileReader(CsvReaderContext(), StringReaderImpl(data), LoggerNop).readAllWithHeaderAsSequence().toList()
 }


### PR DESCRIPTION
# Suggestion for #94 

External dependencies should be prevented. Users still might want to log at runtime. This commit introduces a logging interface, which mimics the current behavior, while opening up the api and make it possible to _provide_ implementations, which match users' needs. It comes with a default no-op implementation and removes the `microutils` dependency.