### PR TITLE
Skip line terminator for empty rows.

### DIFF
--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -49,7 +49,7 @@ class CsvFileWriter internal constructor(
         willWritePreTerminator()
         rows.forEachIndexed { index, list ->
             writeNext(list)
-            if (index < rows.size - 1) {
+            if (index < rows.size - 1 && list.isNotEmpty()) {
                 writeTerminator()
             }
         }

--- a/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
+++ b/src/jvmMain/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriter.kt
@@ -67,8 +67,9 @@ class CsvFileWriter internal constructor(
 
         val itr = rows.iterator()
         while (itr.hasNext()) {
-            writeNext(itr.next())
-            if (itr.hasNext()) writeTerminator()
+            val row = itr.next()
+            writeNext(row)
+            if (itr.hasNext() && row.isNotEmpty()) writeTerminator()
         }
 
         willWriteEndTerminator()

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
@@ -98,6 +98,15 @@ class CsvFileWriterTest : WordSpec({
             val actual = readTestFile()
             actual shouldBe expected
         }
+        "write no line terminator when row is empty" {
+            val rows = listOf(listOf("a", "b", "c"), listOf(), listOf("d", "e", "f")).asSequence()
+            val expected = "a,b,c\r\nd,e,f\r\n"
+            csvWriter().open(testFileName) {
+                writeRows(rows)
+            }
+            val actual = readTestFile()
+            actual shouldBe expected
+        }
     }
     "close method" should {
         "throw Exception when stream is already closed" {

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvFileWriterTest.kt
@@ -98,7 +98,16 @@ class CsvFileWriterTest : WordSpec({
             val actual = readTestFile()
             actual shouldBe expected
         }
-        "write no line terminator when row is empty" {
+        "write no line terminator when row is empty for rows from list" {
+            val rows = listOf(listOf("a", "b", "c"), listOf(), listOf("d", "e", "f"))
+            val expected = "a,b,c\r\nd,e,f\r\n"
+            csvWriter().open(testFileName) {
+                writeRows(rows)
+            }
+            val actual = readTestFile()
+            actual shouldBe expected
+        }
+        "write no line terminator when row is empty for rows from sequence" {
             val rows = listOf(listOf("a", "b", "c"), listOf(), listOf("d", "e", "f")).asSequence()
             val expected = "a,b,c\r\nd,e,f\r\n"
             csvWriter().open(testFileName) {


### PR DESCRIPTION
Closes #122 

Skip line terminator for empty rows writing from lists and sequences.