### PR TITLE
Skip Notification Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,25 @@ val tsvReader = csvReader {
     escapeChar = '\\'
 }
 ```
+#### Listening Interface for Skipped Row Events
+```kotlin
+csvReader {
+    excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE
+    insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE
+    onSkippedEvent = skipNotification {
+        listeners["id"] = SkipNotify { println(it) }
+    }
+}
+```
 
+* skipNotification - builder function for creating notification listener
+* listeners `Mutable<String, ISkippedRow>` - map of listener function to be notified 
+* `SkipNotify` - functional interface template
+```kotlin
+fun interface SkipNotify {
+    fun onSkipped(row: SkippedRow)
+}
+```
 | Option                         | default value | description                                                                                                                                                                                                                                                                            |
 |--------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | logger                         | _no-op_       | Logger instance for logging debug information at runtime.                                                                                                                                                                                                                              |
@@ -176,26 +194,6 @@ val tsvReader = csvReader {
 | excessFieldsRowBehaviour       | `ERROR`       | Behaviour to use when a row has more fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `TRIM` (remove the excess fields at the end of the row to match the expected number of fields).                                                                     |
 | insufficientFieldsRowBehaviour | `ERROR`       | Behaviour to use when a row has fewer fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `EMPTY_STRING` (replace missing fields with an empty string).                                                                                                      |
 | onSkippedEvent                 | `null`        | A pluggable Interface on listening when skipping either an insufficient or an excess number of fields.                                                                                                                                                                                 |
-
-#### Interface Listing to Skipped Row Events`
-```kotlin
-csvReader {
-    excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE
-    insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE
-    onSkippedEvent = skipNotification {
-        listeners["id"] = SkipNotify { println(it) }
-    }
-}
-```
-
-* skipNotification - builder function for creating notification listener
-* listeners `Mutable<String, ISkippedRow>` - map of listener function that will be triggered
-* `SkipNotify` - functional interface template
-```kotlin
-fun interface SkipNotify {
-    fun onSkipped(row: SkippedRow)
-}
-```
 
 ### CSV Write examples
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,27 @@ val tsvReader = csvReader {
 | ~~skipMissMatchedRow~~         | `false`       | Deprecated. Replace with appropriate values in `excessFieldsRowBehaviour` and `insufficientFieldsRowBehaviour`, e.g. both set to `IGNORE`. ~~Whether to skip an invalid row. If `ignoreExcessCols` is true, only rows with less than the expected number of columns will be skipped.~~ |
 | excessFieldsRowBehaviour       | `ERROR`       | Behaviour to use when a row has more fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `TRIM` (remove the excess fields at the end of the row to match the expected number of fields).                                                                     |
 | insufficientFieldsRowBehaviour | `ERROR`       | Behaviour to use when a row has fewer fields (columns) than expected. `ERROR` (default), `IGNORE` (skip the row) or `EMPTY_STRING` (replace missing fields with an empty string).                                                                                                      |
+| onSkippedEvent                 | `null`        | A pluggable Interface on listening when skipping either an insufficient or an excess number of fields.                                                                                                                                                                                 |
+
+#### Interface Listing to Skipped Row Events`
+```kotlin
+csvReader {
+    excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE
+    insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE
+    onSkippedEvent = skipNotification {
+        listeners["id"] = SkipNotify { println(it) }
+    }
+}
+```
+
+* skipNotification - builder function for creating notification listener
+* listeners `Mutable<String, ISkippedRow>` - map of listener function that will be triggered
+* `SkipNotify` - functional interface template
+```kotlin
+fun interface SkipNotify {
+    fun onSkipped(row: SkippedRow)
+}
+```
 
 ### CSV Write examples
 

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/dsl/context/CsvReaderContext.kt
@@ -1,5 +1,6 @@
 package com.github.doyaaaaaken.kotlincsv.dsl.context
 
+import com.github.doyaaaaaken.kotlincsv.event.skip.INotifySkippedEvent
 import com.github.doyaaaaaken.kotlincsv.util.Const
 import com.github.doyaaaaaken.kotlincsv.util.CsvDslMarker
 import com.github.doyaaaaaken.kotlincsv.util.logger.Logger
@@ -88,6 +89,11 @@ interface ICsvReaderContext {
      * If a row exceeds have the expected number of fields (columns), how, and if, the reader should proceed
      */
     val excessFieldsRowBehaviour: ExcessFieldsRowBehaviour
+
+    /**
+     * A pluggable Interface on listening when skipping either an insufficient or an excess number of fields
+     */
+    val onSkippedEvent: INotifySkippedEvent?
 }
 
 enum class InsufficientFieldsRowBehaviour {
@@ -142,4 +148,5 @@ class CsvReaderContext : ICsvReaderContext {
     override var autoRenameDuplicateHeaders: Boolean = false
     override var insufficientFieldsRowBehaviour: InsufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.ERROR
     override var excessFieldsRowBehaviour: ExcessFieldsRowBehaviour = ExcessFieldsRowBehaviour.ERROR
+    override var onSkippedEvent: INotifySkippedEvent? = null
 }

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/CsvSkipEvent.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/CsvSkipEvent.kt
@@ -1,0 +1,18 @@
+package com.github.doyaaaaaken.kotlincsv.event.skip
+
+
+fun interface SkipNotify {
+    fun onSkipped(row: SkippedRow)
+}
+
+/**
+ * interface function that will be triggered when skipping either insufficient or excess number of fields
+ */
+fun interface INotifySkippedEvent {
+   fun notify(skippedRow: SkippedRow)
+}
+
+
+fun skipNotification(block: NotifySkipEvent.() -> Unit): INotifySkippedEvent {
+    return NotifySkipEvent().apply(block)
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/NotifySkipEvent.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/NotifySkipEvent.kt
@@ -1,0 +1,8 @@
+package com.github.doyaaaaaken.kotlincsv.event.skip
+
+class NotifySkipEvent: INotifySkippedEvent {
+    val listeners = mutableMapOf<String, SkipNotify>()
+    override fun notify(skippedRow: SkippedRow) {
+        listeners.forEach { (_, value) -> value.onSkipped(skippedRow) }
+    }
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/SkipType.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/SkipType.kt
@@ -1,0 +1,5 @@
+package com.github.doyaaaaaken.kotlincsv.event.skip
+enum class SkipType {
+    InsufficientFieldsRowBehaviour,
+    ExcessFieldsRowBehaviour
+}

--- a/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/SkippedRow.kt
+++ b/src/commonMain/kotlin/com/github/doyaaaaaken/kotlincsv/event/skip/SkippedRow.kt
@@ -1,0 +1,24 @@
+package com.github.doyaaaaaken.kotlincsv.event.skip
+
+/**
+ *  data class containing relevant information
+ */
+data class SkippedRow(
+    /**
+     * row index in the csv file
+     */
+    val idx: Int,
+    /**
+     * row values
+     */
+    val row: List<String>,
+    /**
+     * reason for skipping
+     */
+    val message: String,
+    /**
+     * type of skip
+     */
+    val skipType: SkipType
+
+)

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReaderTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReaderTest.kt
@@ -4,6 +4,8 @@ import com.github.doyaaaaaken.kotlincsv.dsl.context.CsvReaderContext
 import com.github.doyaaaaaken.kotlincsv.dsl.context.ExcessFieldsRowBehaviour
 import com.github.doyaaaaaken.kotlincsv.dsl.context.InsufficientFieldsRowBehaviour
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
+import com.github.doyaaaaaken.kotlincsv.event.skip.SkipNotify
+import com.github.doyaaaaaken.kotlincsv.event.skip.skipNotification
 import com.github.doyaaaaaken.kotlincsv.util.CSVFieldNumDifferentException
 import com.github.doyaaaaaken.kotlincsv.util.CSVParseFormatException
 import com.github.doyaaaaaken.kotlincsv.util.Const
@@ -199,6 +201,22 @@ class CsvReaderTest : WordSpec({
                 csvReader {
                     excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE
                     insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE
+                }.readAll(readTestDataFile("varying-column-lengths.csv"))
+
+            assertSoftly {
+                actual shouldBe expected
+                actual.size shouldBe 1
+            }
+        }
+        "it should be be possible to listen to to skip events for insufficient or excess fields " {
+            val expected = listOf(listOf("a", "b"))
+            val actual =
+                csvReader {
+                    excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE
+                    insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE
+                    onSkippedEvent = skipNotification {
+                        listeners["id"] = SkipNotify { println(it) }
+                    }
                 }.readAll(readTestDataFile("varying-column-lengths.csv"))
 
             assertSoftly {

--- a/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReaderTest.kt
+++ b/src/jvmTest/kotlin/com/github/doyaaaaaken/kotlincsv/client/CsvReaderTest.kt
@@ -208,7 +208,7 @@ class CsvReaderTest : WordSpec({
                 actual.size shouldBe 1
             }
         }
-        "it should be be possible to listen to to skip events for insufficient or excess fields " {
+        "it should be be possible to listen to skip events for insufficient or excess fields " {
             val expected = listOf(listOf("a", "b"))
             val actual =
                 csvReader {


### PR DESCRIPTION
Closes #129 Allow An Error Interface

Feature Request to allow to listen on what rows are skipped during read all with headers.

This is specially useful for real business use cases  where csv data can have erroneous entries, where later business need to correct those entries for re-processing purpose, as well as logging purpose.