### PR TITLE
version up KMP to 2.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,8 +38,7 @@ jobs:
 
       - name: Run checks and generate report
         run: |
-          ./gradlew clean check
-          ./gradlew jacocoTestReport
+          ./gradlew clean check koverXmlReport
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test.csv
 
 # Ignore yarn.lcok
 kotlin-js-store/yarn.lock
+
+# Kotlin 2.0
+.kotlin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,9 @@
 plugins {
-    java
     kotlin("multiplatform") version "2.1.0"
     id("org.jetbrains.dokka").version("1.7.20")
+    id("org.jetbrains.kotlinx.kover") version "0.9.0"
     `maven-publish`
     signing
-    jacoco
 }
 
 group = "com.jsoizo"
@@ -129,31 +128,4 @@ publishing {
 
 signing {
     sign(publishing.publications)
-}
-
-/////////////////////////////////////////
-//         Jacoco setting              //
-/////////////////////////////////////////
-jacoco {
-    toolVersion = "0.8.8"
-}
-tasks.jacocoTestReport {
-    val coverageSourceDirs = arrayOf(
-        "commonMain/src",
-        "jvmMain/src"
-    )
-    val classFiles = File("${buildDir}/classes/kotlin/jvm/")
-        .walkBottomUp()
-        .toSet()
-    classDirectories.setFrom(classFiles)
-    sourceDirectories.setFrom(files(coverageSourceDirs))
-    additionalSourceDirs.setFrom(files(coverageSourceDirs))
-
-    executionData
-        .setFrom(files("${buildDir}/jacoco/jvmTest.exec"))
-
-    reports {
-        xml.required.set(true)
-        html.required.set(false)
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    kotlin("multiplatform") version "1.7.21"
+    kotlin("multiplatform") version "2.1.0"
     id("org.jetbrains.dokka").version("1.7.20")
     `maven-publish`
     signing
@@ -38,7 +38,7 @@ kotlin {
             artifact(dokkaJar)
         }
     }
-    js(BOTH) {
+    js {
         browser {
         }
         nodejs {


### PR DESCRIPTION
- Update KMP version to use the latest features. 
- Remove `java` Gradle plugin because it is incompatible with the KMP plugin
- Replace JaCoCo with kotlinx-kover since JaCoCo requires the Java plugin