### PR TITLE
Add Kotlin/Native targets

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,8 +7,9 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  linux:
+    name: Linux, JVM, JS, and coverage
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -23,12 +24,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Verify dependencies
-        run: ./gradlew dependencies
-
-      - name: Run checks and generate report
+      - name: Run Linux, JVM, JS checks and generate coverage report
         run: |
-          ./gradlew clean check koverXmlReport
+          ./gradlew clean jvmTest jsNodeTest linuxX64Test compileKotlinLinuxArm64 compileTestKotlinLinuxArm64 checkKotlinAbi koverXmlReport
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4
@@ -36,3 +34,44 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+  apple:
+    name: Apple Native
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Apple Native checks
+        run: |
+          ./gradlew macosArm64Test iosSimulatorArm64Test compileKotlinIosArm64 compileTestKotlinIosArm64
+
+  windows:
+    name: Windows Native
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Windows Native checks
+        run: ./gradlew.bat mingwX64Test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">kotlin-csv</h1>
+# kotlin-csv
 
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-2.0.0-blue.svg?cacheSeconds=2592000" />
@@ -15,20 +15,26 @@
 
 Pure Kotlin Multiplatform CSV reader and writer.
 
-# Setup
+## Setup
 
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-implementation("com.jsoizo:kotlin-csv-jvm:2.0.0") // JVM
-implementation("com.jsoizo:kotlin-csv-js:2.0.0")  // Kotlin/JS (Node.js)
+implementation("com.jsoizo:kotlin-csv:2.0.0")
 ```
+
+The multiplatform artifact resolves JVM, JS, and supported Kotlin/Native variants
+from Kotlin Multiplatform projects. Published Native targets are
+`macosArm64`, `iosArm64`, `iosSimulatorArm64`, `linuxX64`, `linuxArm64`, and `mingwX64`.
+
+Single-platform Gradle projects can also depend on the platform artifact
+directly, for example `kotlin-csv-jvm`, `kotlin-csv-js`,
+`kotlin-csv-macosarm64`, or `kotlin-csv-linuxx64`.
 
 ### Gradle (Groovy DSL)
 
 ```groovy
-implementation 'com.jsoizo:kotlin-csv-jvm:2.0.0' // JVM
-implementation 'com.jsoizo:kotlin-csv-js:2.0.0'  // Kotlin/JS (Node.js)
+implementation 'com.jsoizo:kotlin-csv:2.0.0'
 ```
 
 ### Maven
@@ -44,13 +50,6 @@ implementation 'com.jsoizo:kotlin-csv-js:2.0.0'  // Kotlin/JS (Node.js)
   <artifactId>kotlin-csv-js</artifactId>
   <version>2.0.0</version>
 </dependency>
-```
-
-### [kscript](https://github.com/holgerbrandl/kscript)
-
-```kotlin
-@file:DependsOn("com.jsoizo:kotlin-csv-jvm:2.0.0")
-@file:DependsOn("com.jsoizo:kotlin-csv-js:2.0.0")
 ```
 
 ### SNAPSHOT builds
@@ -78,24 +77,10 @@ dependencyResolutionManagement {
 
 ```kotlin
 // build.gradle.kts
-implementation("com.jsoizo:kotlin-csv-jvm:<VERSION>-SNAPSHOT") // for JVM platform
-implementation("com.jsoizo:kotlin-csv-js:<VERSION>-SNAPSHOT")  // for Kotlin JS platform
+implementation("com.jsoizo:kotlin-csv:<VERSION>-SNAPSHOT")
 ```
 
-#### Maven
-
-```xml
-<repositories>
-  <repository>
-    <id>central-portal-snapshots</id>
-    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-    <releases><enabled>false</enabled></releases>
-    <snapshots><enabled>true</enabled></snapshots>
-  </repository>
-</repositories>
-```
-
-# Quick start
+## Quick start
 
 The DSL builders return reusable, stateless instances; create them once and
 share them across calls.
@@ -108,7 +93,7 @@ val reader = csvReader()
 val writer = csvWriter()
 ```
 
-## Read
+### Read
 
 ```kotlin
 // From a String — eager
@@ -133,7 +118,7 @@ without parsing the rest of the file. For in-memory streams use
 `reader.read(source)` (commonMain `kotlinx.io.Source`) or
 `reader.read(stream)` (JVM `java.io.InputStream`).
 
-## Write
+### Write
 
 ```kotlin
 val rows = listOf(
@@ -155,7 +140,7 @@ and (on JVM) `java.io.File`. For in-memory streams use
 `Sequence<List<String>>` and `List<List<String>>` are accepted as the row
 source.
 
-# Configuration
+## Configuration
 
 Reader and writer share a `CsvDialect` value object that holds the four
 characters defining the CSV format itself: `delimiter`, `quoteChar`,
@@ -204,7 +189,7 @@ reader.readFromFile(File("data.csv"), options = CsvReadIoOptions(stripBom = fals
 writer.writeToFile(rows, File("out.csv"), options = CsvWriteIoOptions(prependBom = true))
 ```
 
-# More
+## More
 
 - **Migration from kotlin-csv 1.x**:
   see [V2_MIGRATION_GUIDE.md](./V2_MIGRATION_GUIDE.md).
@@ -212,14 +197,14 @@ writer.writeToFile(rows, File("out.csv"), options = CsvWriteIoOptions(prependBom
   HTML to `build/dokka/html/`.
 - **Change Logs**: see [GitHub releases](https://github.com/jsoizo/kotlin-csv/releases).
 
-# Miscellaneous
+## Miscellaneous
 
-## 🤝 Contributing
+### 🤝 Contributing
 
 Contributions, [issues](https://github.com/jsoizo/kotlin-csv/issues) and feature requests are welcome!
 If you have questions, ask away in [Kotlin Slack's](https://kotlinlang.slack.com) `kotlin-csv` room.
 
-## 💻 Development
+### 💻 Development
 
 ```sh
 git clone git@github.com:jsoizo/kotlin-csv.git
@@ -227,18 +212,11 @@ cd kotlin-csv
 ./gradlew check
 ```
 
-## Show your support
-
-Give a ⭐️ if this project helped you!
-
-## 📝 License
+### 📝 License
 
 Copyright © 2024 [jsoizo](https://github.com/jsoizo).
 This project is licensed under [Apache 2.0](LICENSE).
 
-***
-_This project is inspired ❤️ by [scala-csv](https://github.com/tototoshi/scala-csv)_
-
-## Acknowledgments
+### Acknowledgments
 
 This project was originally created by [@doyaaaaaken](https://github.com/doyaaaaaken). The initial work and contributions are greatly appreciated.

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -29,7 +29,8 @@ A reference for upgrading from kotlin-csv 1.x to 2.0.
   `CSVFieldNumDifferentException` -> `CsvFieldNumDifferentException`.
   Row indices on exceptions are now `Long`.
 - **kotlinx-io**: added as a transitive dependency. JS gets file I/O for
-  the first time (Node.js only).
+  the first time (Node.js only), and the same common I/O API is available
+  on Kotlin/Native.
 - **No suspend API**: `openAsync` / `writeAllAsync` are removed. Wrap
   `readFromFile` / `writeToFile` (or `read` / `write` for in-memory streams)
   in `withContext(Dispatchers.IO) { ... }` if needed.
@@ -41,15 +42,22 @@ A reference for upgrading from kotlin-csv 1.x to 2.0.
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-implementation("com.jsoizo:kotlin-csv-jvm:2.0.0") // JVM
-implementation("com.jsoizo:kotlin-csv-js:2.0.0")  // Kotlin/JS
+implementation("com.jsoizo:kotlin-csv:2.0.0")
 ```
+
+The multiplatform artifact resolves JVM, JS, and supported Kotlin/Native
+variants from Kotlin Multiplatform projects. Published Native targets are
+`macosArm64`, `iosArm64`, `iosSimulatorArm64`, `linuxX64`, `linuxArm64`,
+and `mingwX64`.
+
+Single-platform Gradle projects can also depend on the platform artifact
+directly, for example `kotlin-csv-jvm`, `kotlin-csv-js`,
+`kotlin-csv-macosarm64`, or `kotlin-csv-linuxx64`.
 
 ### Gradle (Groovy DSL)
 
 ```groovy
-implementation 'com.jsoizo:kotlin-csv-jvm:2.0.0'
-implementation 'com.jsoizo:kotlin-csv-js:2.0.0'
+implementation 'com.jsoizo:kotlin-csv:2.0.0'
 ```
 
 ### Maven
@@ -302,8 +310,9 @@ reader.readFromFile(file, options = CsvReadIoOptions(stripBom = false)) { ... }
 
 - **`CsvDialect`** is the shared format value object. Two presets are
   built in: `CsvDialect.RFC4180` (the default) and `CsvDialect.TSV`.
-- **JS file I/O** (Node.js): `reader.readFromFile(path) { ... }` and
-  `writer.writeToFile(rows, path)` work on Kotlin/JS for the first time.
+- **JS and Native file I/O**: `reader.readFromFile(path) { ... }` and
+  `writer.writeToFile(rows, path)` work from common code through
+  `kotlinx.io.files.Path`. JS file I/O is Node.js only.
   See §9 for the streaming caveat.
 - **`Sequence`-first core**: `reader.read(chars: Sequence<Char>)` returns
   a cold `Sequence<List<String>>`; `writer.write(rows: Sequence<List<String>>)`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,14 @@ kotlin {
         nodejs {
         }
     }
+
+    macosArm64()
+    iosArm64()
+    iosSimulatorArm64()
+    linuxX64()
+    linuxArm64()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- Add Kotlin/Native targets for macOS, iOS, Linux, and MinGW
- Update README dependency guidance for the multiplatform artifact and Native target support
- Update the v2 migration guide to mention Native common I/O support

close: #15
close: #151

## Verification
- ./gradlew check
- ./gradlew publishToMavenLocal