### PR TITLE
Add wasmWasi target

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run Linux, JVM, JS checks and generate coverage report
         run: |
-          ./gradlew clean jvmTest jsNodeTest linuxX64Test compileKotlinLinuxArm64 compileTestKotlinLinuxArm64 checkKotlinAbi koverXmlReport
+          ./gradlew clean jvmTest jsNodeTest linuxX64Test compileKotlinLinuxArm64 compileTestKotlinLinuxArm64 compileKotlinWasmWasi checkKotlinAbi koverXmlReport
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SourcesJar
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -40,6 +41,11 @@ kotlin {
     linuxArm64()
     mingwX64()
 
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
+
     sourceSets {
         commonMain {
             dependencies {
@@ -71,6 +77,12 @@ kotlin {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+}
+
+// Kotest 6.x does not publish wasmWasi artifacts yet, so commonTest cannot be
+// compiled for this target. Validate main compilation only until upstream support lands.
+listOf("compileTestKotlinWasmWasi", "wasmWasiTest", "wasmWasiNodeTest").forEach { taskName ->
+    tasks.matching { it.name == taskName }.configureEach { enabled = false }
 }
 
 // Kotest 6.x JVM artifacts are built with Java 11 bytecode, while the library


### PR DESCRIPTION
## Summary
- Declare `wasmWasi(nodejs)` so `commonMain` (kotlinx-io based reader/writer) compiles for WASI runtimes.
- Disable `compileTestKotlinWasmWasi` / `wasmWasiTest` / `wasmWasiNodeTest` for now: Kotest 6.x does not publish wasmWasi artifacts yet, so `commonTest` cannot be compiled for this target. Re-enable once upstream support lands.
- Add `compileKotlinWasmWasi` to the Linux CI job to guard against regressions.

## Test plan
- [x] `./gradlew compileKotlinWasmWasi` succeeds locally
- [x] `./gradlew clean jvmTest jsNodeTest linuxX64Test compileKotlinLinuxArm64 compileTestKotlinLinuxArm64 compileKotlinWasmWasi checkKotlinAbi koverXmlReport` succeeds locally
- [x] CI passes on Linux / Apple / Windows jobs