### PR TITLE
Add direct writer fast path

### DIFF
--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/CsvWriter.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/CsvWriter.kt
@@ -1,5 +1,6 @@
 package com.jsoizo.kotlincsv.writer
 
+import com.jsoizo.kotlincsv.writer.internal.appendRows
 import com.jsoizo.kotlincsv.writer.internal.encodeRows
 
 /**
@@ -12,6 +13,7 @@ class CsvWriter(val config: CsvWriterConfig = CsvWriterConfig()) {
     fun write(rows: Sequence<List<String>>): Sequence<Char> = encodeRows(rows, config)
 
     /** Eagerly encode [rows] into a single CSV string. */
-    fun writeAll(rows: List<List<String>>): String =
-        write(rows.asSequence()).joinToString("")
+    fun writeAll(rows: List<List<String>>): String = buildString {
+        appendRows(rows.asSequence(), config, this)
+    }
 }

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIo.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIo.kt
@@ -1,5 +1,6 @@
 package com.jsoizo.kotlincsv.writer
 
+import com.jsoizo.kotlincsv.writer.internal.appendRows
 import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -22,17 +23,9 @@ fun CsvWriter.write(
     if (options.prependBom) {
         sink.writeString(BOM_STRING)
     }
-    val buffer = StringBuilder(WRITE_CHUNK_SIZE)
-    for (ch in write(rows)) {
-        buffer.append(ch)
-        if (buffer.length >= WRITE_CHUNK_SIZE) {
-            sink.writeString(buffer.toString())
-            buffer.clear()
-        }
-    }
-    if (buffer.isNotEmpty()) {
-        sink.writeString(buffer.toString())
-    }
+    val out = SinkAppendable(sink)
+    appendRows(rows, config, out)
+    out.flush()
     sink.flush()
 }
 
@@ -77,3 +70,42 @@ fun CsvWriter.writeToFile(
     filePath: String,
     options: CsvWriteIoOptions = CsvWriteIoOptions(),
 ) = writeToFile(rows.asSequence(), filePath, options)
+
+private class SinkAppendable(
+    private val sink: Sink,
+) : Appendable {
+    private val buffer = StringBuilder(WRITE_CHUNK_SIZE)
+
+    override fun append(value: Char): Appendable {
+        buffer.append(value)
+        flushIfFull()
+        return this
+    }
+
+    override fun append(value: CharSequence?): Appendable {
+        val text = value ?: "null"
+        return append(text, 0, text.length)
+    }
+
+    override fun append(value: CharSequence?, startIndex: Int, endIndex: Int): Appendable {
+        val text = value ?: "null"
+        for (index in startIndex until endIndex) {
+            buffer.append(text[index])
+            flushIfFull()
+        }
+        return this
+    }
+
+    fun flush() {
+        if (buffer.isNotEmpty()) {
+            sink.writeString(buffer.toString())
+            buffer.clear()
+        }
+    }
+
+    private fun flushIfFull() {
+        if (buffer.length >= WRITE_CHUNK_SIZE) {
+            flush()
+        }
+    }
+}

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/internal/SequenceEncoder.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/internal/SequenceEncoder.kt
@@ -27,6 +27,31 @@ internal fun encodeRows(
     }
 }
 
+/**
+ * Eagerly encode [rows] into [out] without routing every character through a
+ * `Sequence<Char>`. Used by String and I/O writers; [encodeRows] remains the
+ * lazy public-core path.
+ */
+internal fun appendRows(
+    rows: Sequence<List<String>>,
+    config: CsvWriterConfig,
+    out: Appendable,
+) {
+    val dialect = config.dialect
+    val lineTerminator = dialect.lineTerminator
+    val iter = rows.iterator()
+    if (!iter.hasNext()) return
+
+    appendRow(iter.next(), dialect, config.quoteMode, out)
+    while (iter.hasNext()) {
+        out.append(lineTerminator)
+        appendRow(iter.next(), dialect, config.quoteMode, out)
+    }
+    if (config.outputLastLineTerminator) {
+        out.append(lineTerminator)
+    }
+}
+
 private fun encodeRow(
     row: List<String>,
     dialect: CsvDialect,
@@ -37,6 +62,21 @@ private fun encodeRow(
     for (field in row) {
         if (!first) yield(delimiter)
         yieldAll(encodeField(field, dialect, quoteMode))
+        first = false
+    }
+}
+
+private fun appendRow(
+    row: List<String>,
+    dialect: CsvDialect,
+    quoteMode: WriteQuoteMode,
+    out: Appendable,
+) {
+    val delimiter = dialect.delimiter
+    var first = true
+    for (field in row) {
+        if (!first) out.append(delimiter)
+        appendField(field, dialect, quoteMode, out)
         first = false
     }
 }
@@ -71,6 +111,42 @@ private fun encodeField(
         }
     }
     if (shouldQuote) yield(quoteChar)
+}
+
+private fun appendField(
+    field: String,
+    dialect: CsvDialect,
+    quoteMode: WriteQuoteMode,
+    out: Appendable,
+) {
+    val quoteChar = dialect.quoteChar
+    val escapeChar = dialect.escapeChar
+
+    val shouldQuote = when (quoteMode) {
+        WriteQuoteMode.ALL -> true
+        WriteQuoteMode.CANONICAL ->
+            needsCanonicalQuote(field, quoteChar, escapeChar, dialect.delimiter, dialect.lineTerminator)
+        WriteQuoteMode.NON_NUMERIC -> !isDecimalNumber(field)
+    }
+
+    if (shouldQuote) out.append(quoteChar)
+    if (escapeChar == quoteChar) {
+        // RFC 4180 §2.7 doubling style.
+        for (ch in field) {
+            if (ch == quoteChar) out.append(quoteChar)
+            out.append(ch)
+        }
+    } else {
+        // Explicit escape style (CSV extension).
+        for (ch in field) when (ch) {
+            quoteChar, escapeChar -> {
+                out.append(escapeChar)
+                out.append(ch)
+            }
+            else -> out.append(ch)
+        }
+    }
+    if (shouldQuote) out.append(quoteChar)
 }
 
 private fun needsCanonicalQuote(

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
@@ -110,6 +110,25 @@ class WriterIoTest {
     }
 
     @Test
+    fun writerPaths_produceSameCsvForComplexRows() {
+        val rows = listOf(
+            listOf("a,b", "c\"d", "plain"),
+            emptyList(),
+            listOf("line\nbreak", "slash\\value", ""),
+        )
+        val writer = CsvWriter(CsvWriterConfig(dialect = com.jsoizo.kotlincsv.CsvDialect(escapeChar = '\\')))
+        val expected = writer.write(rows.asSequence()).joinToString("")
+
+        writer.writeAll(rows) shouldBe expected
+
+        val raw = FakeRawSink()
+        raw.buffered().use { sink ->
+            writer.write(rows, sink)
+        }
+        raw.snapshot().decodeToString() shouldBe expected
+    }
+
+    @Test
     fun write_sink_largeOutputCrossesChunkBoundary() {
         // Force the chunked flushing path: produce >8192 chars of output.
         val row = List(200) { "x" }

--- a/src/jvmMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIoJvm.kt
+++ b/src/jvmMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIoJvm.kt
@@ -1,12 +1,13 @@
 package com.jsoizo.kotlincsv.writer
 
+import com.jsoizo.kotlincsv.writer.internal.appendRows
+import java.io.BufferedWriter
 import java.io.File
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.nio.charset.Charset
 
 private const val BOM_STRING = "\uFEFF"
-private const val WRITE_CHUNK_SIZE = 8192
 
 /**
  * Encode [rows] and write to [file] using [charset]. The file is truncated,
@@ -33,22 +34,12 @@ fun CsvWriter.write(
     charset: String = "UTF-8",
     options: CsvWriteIoOptions = CsvWriteIoOptions(),
 ) {
-    val osw = OutputStreamWriter(stream, Charset.forName(charset))
+    val writer = BufferedWriter(OutputStreamWriter(stream, Charset.forName(charset)))
     if (options.prependBom) {
-        osw.write(BOM_STRING)
+        writer.write(BOM_STRING)
     }
-    val buffer = StringBuilder(WRITE_CHUNK_SIZE)
-    for (ch in write(rows)) {
-        buffer.append(ch)
-        if (buffer.length >= WRITE_CHUNK_SIZE) {
-            osw.write(buffer.toString())
-            buffer.clear()
-        }
-    }
-    if (buffer.isNotEmpty()) {
-        osw.write(buffer.toString())
-    }
-    osw.flush()
+    appendRows(rows, config, writer)
+    writer.flush()
 }
 
 /** @see writeToFile */

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
@@ -110,6 +110,23 @@ class CsvWriterJvmIoTest {
     }
 
     @Test
+    fun write_stream_matchesLazyAndEagerPathsForComplexRows() {
+        val rows = listOf(
+            listOf("a,b", "c\"d", "plain"),
+            emptyList(),
+            listOf("line\nbreak", "slash\\value", ""),
+        )
+        val writer = CsvWriter()
+        val expected = writer.write(rows.asSequence()).joinToString("")
+
+        writer.writeAll(rows) shouldBe expected
+
+        val raw = ByteArrayOutputStream()
+        writer.write(rows, raw)
+        raw.toByteArray().toString(Charsets.UTF_8) shouldBe expected
+    }
+
+    @Test
     fun write_stream_largeOutputCrossesChunkBoundary() {
         // Force the chunked flushing path: produce >8192 chars of output.
         val row = List(200) { "x" }


### PR DESCRIPTION
## Summary
- keep the public lazy `Sequence<Char>` writer API intact
- add a direct append encoder for eager String and I/O writer paths
- route common Sink and JVM OutputStream writers through the direct append path
- add equivalence coverage across lazy, eager, Sink, and OutputStream writer paths

## Verification
- [x] `./gradlew check`

## Benchmark results

Measured on the same machine as issue #172 (Apple M4 / 32 GB / JDK 21.0.6 / JMH 1.36, seed=42), `primary` profile (warmup=5 / iter=5 / fork=2 / 10s).

- **Before** = v2.0.0 primary numbers from [issue #172 primary comment](https://github.com/jsoizo/kotlin-csv/issues/172#issuecomment-4472909584) (commit `7fe79b4`). Writer source and `benchmark/v2` code are unchanged between `7fe79b4` and `3decc39^` (verified by diff — only reader/test files differ), so the issue numbers are a valid Before for this PR.
- **After** = this PR (`3decc39`), measured 2026-05-22.

### Throughput (ops/ms, higher is better)

| Workload | Dataset | Before | After | Delta | vs v1.10.0 |
|---|---:|---:|---:|---:|---:|
| `writeAll(OutputStream -> null)` | SMALL  | 0.4905  | **2.0074 ± 0.0117** | **+309%** (4.09×) | **1.60× faster** |
| `writeAll(OutputStream -> null)` | MEDIUM | 0.00229 | **0.0096 ± 0.0002** | **+319%** (4.19×) | **1.81× faster** |
| `writeAll(OutputStream -> null)` | HARD   | 0.0161  | **0.1281 ± 0.0047** | **+696%** (7.96×) | **1.66× faster** |
| `writeAll(File)`                 | SMALL  | 0.3789  | **1.5413 ± 0.0315** | **+307%** (4.07×) | **2.10× faster** |
| `writeAll(File)`                 | MEDIUM | 0.00194 | **0.0085 ± 0.0001** | **+338%** (4.38×) | **2.51× faster** |
| `writeAll(File)`                 | HARD   | 0.0328  | **0.1169 ± 0.0014** | **+256%** (3.56×) | **2.31× faster** |

### Average time (ms/op, lower is better)

| Workload | Dataset | Before | After | Delta |
|---|---:|---:|---:|---:|
| `writeAll(OutputStream -> null)` | SMALL  | 5.32    | **0.500 ± 0.004** | **10.6× faster** |
| `writeAll(OutputStream -> null)` | MEDIUM | 837.67  | **103.42 ± 0.40** | **8.1× faster**  |
| `writeAll(OutputStream -> null)` | HARD   | 33.87   | **7.60 ± 0.05**   | **4.5× faster**  |
| `writeAll(File)`                 | SMALL  | 7.89    | **0.668 ± 0.025** | **11.8× faster** |
| `writeAll(File)`                 | MEDIUM | 1444.30 | **118.26 ± 2.07** | **12.2× faster** |
| `writeAll(File)`                 | HARD   | 86.83   | **8.61 ± 0.12**   | **10.1× faster** |

### Notes

- The avgt × thrpt divergence flagged in the issue #172 primary comment for the writer (`thrpt × avgt ≈ 3` on Before) is resolved on After: `2.0074 × 0.4996 ≈ 1.003`, i.e. clean inverse → no more long-tail allocation behavior on the writer hot path.
- Score errors shrank substantially as well (e.g. OS HARD: Before `0.0161 ± 0.0041` ≈ 25% noise → After `0.1281 ± 0.0047` ≈ 3.7%), consistent with the encoder no longer producing GC-driven outliers.
- Reproduction command:

  ```bash
  ./gradlew :benchmark:v2:jmh -Pbench.profile=primary -Pjmh.include='.*WriteBenchmarksV2.*'
  ```