### PR TITLE
Add chunked reader fast path

### DIFF
--- a/benchmark/v1/build.gradle.kts
+++ b/benchmark/v1/build.gradle.kts
@@ -25,9 +25,6 @@ jmh {
 
     val include = (project.findProperty("jmh.include") as String?)?.let { listOf(it) }
     if (include != null) includes.set(include)
-    (project.findProperty("jmh.warmupIterations") as String?)?.toInt()?.let { warmupIterations.set(it) }
-    (project.findProperty("jmh.iterations") as String?)?.toInt()?.let { iterations.set(it) }
-    (project.findProperty("jmh.fork") as String?)?.toInt()?.let { fork.set(it) }
 
     when (project.findProperty("bench.profile") as String?) {
         "primary" -> {
@@ -75,4 +72,10 @@ jmh {
             profilers.set(listOf("stack"))
         }
     }
+
+    (project.findProperty("jmh.warmupIterations") as String?)?.toInt()?.let { warmupIterations.set(it) }
+    (project.findProperty("jmh.iterations") as String?)?.toInt()?.let { iterations.set(it) }
+    (project.findProperty("jmh.fork") as String?)?.toInt()?.let { fork.set(it) }
+    (project.findProperty("jmh.timeOnIteration") as String?)?.let { timeOnIteration.set(it) }
+    (project.findProperty("jmh.warmup") as String?)?.let { warmup.set(it) }
 }

--- a/benchmark/v2/build.gradle.kts
+++ b/benchmark/v2/build.gradle.kts
@@ -26,9 +26,6 @@ jmh {
 
     val include = (project.findProperty("jmh.include") as String?)?.let { listOf(it) }
     if (include != null) includes.set(include)
-    (project.findProperty("jmh.warmupIterations") as String?)?.toInt()?.let { warmupIterations.set(it) }
-    (project.findProperty("jmh.iterations") as String?)?.toInt()?.let { iterations.set(it) }
-    (project.findProperty("jmh.fork") as String?)?.toInt()?.let { fork.set(it) }
 
     when (project.findProperty("bench.profile") as String?) {
         "primary" -> {
@@ -76,4 +73,10 @@ jmh {
             profilers.set(listOf("stack"))
         }
     }
+
+    (project.findProperty("jmh.warmupIterations") as String?)?.toInt()?.let { warmupIterations.set(it) }
+    (project.findProperty("jmh.iterations") as String?)?.toInt()?.let { iterations.set(it) }
+    (project.findProperty("jmh.fork") as String?)?.toInt()?.let { fork.set(it) }
+    (project.findProperty("jmh.timeOnIteration") as String?)?.let { timeOnIteration.set(it) }
+    (project.findProperty("jmh.warmup") as String?)?.let { warmup.set(it) }
 }

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReader.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReader.kt
@@ -19,8 +19,18 @@ class CsvReader(val config: CsvReaderConfig = CsvReaderConfig()) {
      * @throws CsvFieldNumDifferentException on terminal operation when a row
      *   violates the configured field-count policy.
      */
-    fun read(chars: Sequence<Char>): Sequence<List<String>> {
-        val parsed = parseRows(chars, config.dialect)
+    fun read(chars: Sequence<Char>): Sequence<List<String>> =
+        applyPipeline(parseRows(chars, config.dialect))
+
+    /** Eagerly parse [text] into a list of rows. */
+    fun readAll(text: String): List<List<String>> = read(text.asSequence()).toList()
+
+    /**
+     * Apply skipEmptyLine filter and field-count policy to a parsed row
+     * sequence. Used by I/O wrappers that obtain rows from chunked parsers
+     * without routing chars through a `Sequence<Char>`.
+     */
+    internal fun applyPipeline(parsed: Sequence<List<String>>): Sequence<List<String>> {
         val filtered = if (config.skipEmptyLine) {
             parsed.filter { row -> !isEmptyRow(row) }
         } else {
@@ -28,9 +38,6 @@ class CsvReader(val config: CsvReaderConfig = CsvReaderConfig()) {
         }
         return applyFieldCountPolicy(filtered)
     }
-
-    /** Eagerly parse [text] into a list of rows. */
-    fun readAll(text: String): List<List<String>> = read(text.asSequence()).toList()
 
     private fun isEmptyRow(row: List<String>): Boolean =
         row.isEmpty() || (row.size == 1 && row.single().isBlank())

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIo.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIo.kt
@@ -1,12 +1,12 @@
 package com.jsoizo.kotlincsv.reader
 
+import com.jsoizo.kotlincsv.reader.internal.parseRowsFromChunks
 import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readCodePointValue
 
-private const val BOM_CODE_POINT = 0xFEFF
 private const val SUPPLEMENTARY_PLANE_START = 0x10000
 private const val HIGH_SURROGATE_BASE = 0xD800
 private const val LOW_SURROGATE_BASE = 0xDC00
@@ -21,7 +21,10 @@ fun <T> CsvReader.read(
     source: Source,
     options: CsvReadIoOptions = CsvReadIoOptions(),
     block: (Sequence<List<String>>) -> T,
-): T = block(read(source.toCharSequence(options.stripBom)))
+): T {
+    val parsed = parseRowsFromChunks(source.asChunkReader(), config.dialect, options.stripBom)
+    return block(applyPipeline(parsed))
+}
 
 /** Eagerly read all CSV rows from [source] (UTF-8). [source] is caller-owned. */
 fun CsvReader.readAll(
@@ -29,23 +32,22 @@ fun CsvReader.readAll(
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = read(source, options) { it.toList() }
 
-private fun Source.toCharSequence(stripBom: Boolean): Sequence<Char> = sequence {
-    var first = true
-    while (!exhausted()) {
+private fun Source.asChunkReader(): (CharArray) -> Int = { buffer ->
+    var index = 0
+    // Stop one slot before the end so a supplementary code point's UTF-16
+    // surrogate pair never spans two chunks. Caller guarantees buffer.size >= 2.
+    val limit = buffer.size - 1
+    while (index < limit && !exhausted()) {
         val codePoint = readCodePointValue()
-        if (first) {
-            first = false
-            if (stripBom && codePoint == BOM_CODE_POINT) continue
-        }
         if (codePoint < SUPPLEMENTARY_PLANE_START) {
-            yield(codePoint.toChar())
+            buffer[index++] = codePoint.toChar()
         } else {
-            // Supplementary plane: emit a UTF-16 surrogate pair.
             val offset = codePoint - SUPPLEMENTARY_PLANE_START
-            yield((HIGH_SURROGATE_BASE + (offset shr 10)).toChar())
-            yield((LOW_SURROGATE_BASE + (offset and LOW_TEN_BIT_MASK)).toChar())
+            buffer[index++] = (HIGH_SURROGATE_BASE + (offset shr 10)).toChar()
+            buffer[index++] = (LOW_SURROGATE_BASE + (offset and LOW_TEN_BIT_MASK)).toChar()
         }
     }
+    index
 }
 
 /**

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/ParseStateMachine.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/ParseStateMachine.kt
@@ -157,9 +157,17 @@ internal class ParseStateMachine(
 
     /**
      * `true` after a row terminator has been consumed. Drivers must read the
-     * row via [getResult] and create a fresh instance before the next row.
+     * row via [getResult] and call [reset] before the next row.
      */
     internal fun isLineComplete(): Boolean = state == ParseState.END
+
+    /** Reset the machine so it can parse the next row without re-allocating. */
+    fun reset() {
+        state = ParseState.START
+        fields.clear()
+        field.clear()
+        pos = 0L
+    }
 
     /**
      * @return return parsed CSV Fields.

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParser.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParser.kt
@@ -2,6 +2,8 @@ package com.jsoizo.kotlincsv.reader.internal
 
 import com.jsoizo.kotlincsv.CsvDialect
 
+private const val BOM_CHAR = '\uFEFF'
+
 /** Lazily parse a `Sequence<Char>` into a `Sequence<List<String>>` of CSV rows. */
 internal fun parseRows(
     chars: Sequence<Char>,
@@ -14,7 +16,7 @@ internal fun parseRows(
     val delimiter = dialect.delimiter
     val escapeChar = dialect.escapeChar
 
-    var stateMachine = ParseStateMachine(quoteChar, delimiter, escapeChar)
+    val stateMachine = ParseStateMachine(quoteChar, delimiter, escapeChar)
     var current: Char = iter.next()
     var skipCount = 0L
     var rowNum = 1L
@@ -32,7 +34,7 @@ internal fun parseRows(
             if (stateMachine.isLineComplete()) {
                 stateMachine.getResult()?.let { yield(it) }
                 rowNum++
-                stateMachine = ParseStateMachine(quoteChar, delimiter, escapeChar)
+                stateMachine.reset()
                 stateMachineHasInput = false
             }
         }
@@ -43,5 +45,95 @@ internal fun parseRows(
 
     if (stateMachineHasInput) {
         stateMachine.getResult()?.let { yield(it) }
+    }
+}
+
+/**
+ * Lazily parse CSV rows from a chunked char source.
+ *
+ * [readInto] fills the supplied `CharArray` and returns the number of chars
+ * written (0 signals EOF). The chunk size is controlled by the caller via the
+ * size of the buffer it receives.
+ *
+ * This path avoids the per-character `sequence { yield(c) }` overhead of
+ * [parseRows] (Continuation allocation per char) by walking the buffer
+ * directly. Per-row yields remain — the public API is still a lazy
+ * `Sequence<List<String>>`.
+ *
+ * Double-buffering is used so the parser can supply the next-char lookahead
+ * across chunk boundaries.
+ */
+internal fun parseRowsFromChunks(
+    readInto: (CharArray) -> Int,
+    dialect: CsvDialect,
+    stripBom: Boolean = false,
+    bufferSize: Int = 8192,
+): Sequence<List<String>> = sequence {
+    require(bufferSize >= 2) { "bufferSize must be >= 2 to hold a UTF-16 surrogate pair" }
+
+    val bufferA = CharArray(bufferSize)
+    val bufferB = CharArray(bufferSize)
+
+    var currentBuffer = bufferA
+    var currentLength = readInto(currentBuffer)
+    if (currentLength <= 0) return@sequence
+
+    var nextBuffer = bufferB
+    var nextLength = readInto(nextBuffer)
+
+    val quoteChar = dialect.quoteChar
+    val delimiter = dialect.delimiter
+    val escapeChar = dialect.escapeChar
+    val machine = ParseStateMachine(quoteChar, delimiter, escapeChar)
+
+    var rowNum = 1L
+    var skipCount = 0L
+    var machineHasInput = false
+    var first = true
+
+    var index = 0
+    while (true) {
+        if (index >= currentLength) {
+            if (nextLength <= 0) break
+            val swap = currentBuffer; currentBuffer = nextBuffer; nextBuffer = swap
+            currentLength = nextLength
+            nextLength = readInto(nextBuffer)
+            index = 0
+        }
+
+        val ch = currentBuffer[index]
+        if (first) {
+            first = false
+            if (stripBom && ch == BOM_CHAR) {
+                index++
+                continue
+            }
+        }
+
+        val nextCh: Char? = when {
+            index + 1 < currentLength -> currentBuffer[index + 1]
+            nextLength > 0 -> nextBuffer[0]
+            else -> null
+        }
+
+        if (skipCount > 0L) {
+            skipCount--
+        } else {
+            skipCount = machine.read(ch, nextCh, rowNum) - 1L
+            machineHasInput = true
+
+            if (machine.isLineComplete()) {
+                machine.getResult()?.let { yield(it) }
+                rowNum++
+                machine.reset()
+                machineHasInput = false
+            }
+        }
+
+        index++
+    }
+
+    if (machineHasInput) {
+        machine.getResult()?.let { yield(it) }
     }
 }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParserTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParserTest.kt
@@ -205,4 +205,76 @@ class SequenceParserTest {
         // and the in-flight row is dropped rather than emitted partial.
         parse("\"abc") shouldBe emptyList()
     }
+
+    private fun chunkedReader(text: String): (CharArray) -> Int {
+        var offset = 0
+        return { buffer ->
+            if (offset >= text.length) {
+                0
+            } else {
+                val end = minOf(text.length, offset + buffer.size)
+                val written = end - offset
+                for (i in 0 until written) buffer[i] = text[offset + i]
+                offset = end
+                written
+            }
+        }
+    }
+
+    private fun parseChunked(
+        text: String,
+        bufferSize: Int = 8192,
+        stripBom: Boolean = false,
+        dialect: CsvDialect = rfc4180,
+    ): List<List<String>> =
+        parseRowsFromChunks(chunkedReader(text), dialect, stripBom, bufferSize).toList()
+
+    @Test
+    fun chunked_emptyInput_yieldsEmptySequence() {
+        // First readInto returns 0 — early-return path.
+        parseChunked("") shouldBe emptyList()
+    }
+
+    @Test
+    fun chunked_smallBuffer_forcesChunkBoundaryAcrossRows() {
+        // bufferSize=4 forces the parser to swap chunks several times mid-row
+        // and to consult the cross-buffer lookahead path.
+        val rows = parseChunked("a,bbb\nccc,d\nef,gh", bufferSize = 4)
+        rows shouldBe listOf(listOf("a", "bbb"), listOf("ccc", "d"), listOf("ef", "gh"))
+    }
+
+    @Test
+    fun chunked_bufferBoundaryLandsOnCrLf() {
+        // Tail CR is the last char of one chunk; LF starts the next. The CR
+        // branch must consult lookahead via the next-buffer slot to swallow LF.
+        val rows = parseChunked("ab\r\ncd", bufferSize = 3)
+        rows shouldBe listOf(listOf("ab"), listOf("cd"))
+    }
+
+    @Test
+    fun chunked_requireBufferSizeAtLeastTwo() {
+        shouldThrow<IllegalArgumentException> {
+            parseRowsFromChunks(chunkedReader("a"), rfc4180, bufferSize = 1).toList()
+        }
+    }
+
+    @Test
+    fun chunked_stripsBomWhenRequested() {
+        // bufferSize chosen so BOM and the first field share the leading chunk.
+        val rows = parseChunked("﻿a,b", bufferSize = 4, stripBom = true)
+        rows shouldBe listOf(listOf("a", "b"))
+    }
+
+    @Test
+    fun chunked_preservesBomWhenStripDisabled() {
+        // Default stripBom = false — exercises the default-parameter call.
+        val rows = parseRowsFromChunks(chunkedReader("﻿a"), rfc4180).toList()
+        rows shouldBe listOf(listOf("﻿a"))
+    }
+
+    @Test
+    fun chunked_unterminatedQuote_atChunkBoundary_yieldsNoFinalRow() {
+        // tail-flush path runs but getResult() returns null (QUOTED_FIELD state).
+        parseChunked("\"abc", bufferSize = 2) shouldBe emptyList()
+    }
 }

--- a/src/jvmMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoJvm.kt
+++ b/src/jvmMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoJvm.kt
@@ -1,12 +1,11 @@
 package com.jsoizo.kotlincsv.reader
 
-import java.io.BufferedReader
+import com.jsoizo.kotlincsv.reader.internal.parseRowsFromChunks
 import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.Reader
 import java.nio.charset.Charset
-
-private const val BOM_CHAR = '\uFEFF'
 
 /**
  * Read CSV rows from [file] decoded with [charset] and pass them to [block].
@@ -41,7 +40,8 @@ fun <T> CsvReader.read(
     block: (Sequence<List<String>>) -> T,
 ): T {
     val reader = InputStreamReader(stream, Charset.forName(charset)).buffered()
-    return block(read(reader.toCharSequence(options.stripBom)))
+    val parsed = parseRowsFromChunks(reader.asChunkReader(), config.dialect, options.stripBom)
+    return block(applyPipeline(parsed))
 }
 
 /**
@@ -54,16 +54,7 @@ fun CsvReader.readAll(
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = read(stream, charset, options) { it.toList() }
 
-private fun BufferedReader.toCharSequence(stripBom: Boolean): Sequence<Char> = sequence {
-    var first = true
-    while (true) {
-        val ch = read()
-        if (ch == -1) break
-        val c = ch.toChar()
-        if (first) {
-            first = false
-            if (stripBom && c == BOM_CHAR) continue
-        }
-        yield(c)
-    }
+private fun Reader.asChunkReader(): (CharArray) -> Int = { buffer ->
+    val charsRead = read(buffer)
+    if (charsRead == -1) 0 else charsRead
 }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
@@ -158,4 +158,31 @@ class CsvReaderJvmIoTest {
         CsvReader().readAll(counting) shouldBe sampleRows
         counting.closeCount shouldBe 0
     }
+
+    @Test
+    fun readAll_stream_skipEmptyLine_dropsBlankRows() {
+        // Exercise applyPipeline's skipEmptyLine = true branch from the I/O
+        // path; the String-input tests already cover the same branch.
+        val raw = "a,b\n\nc,d\n".toByteArray(Charsets.UTF_8)
+        val reader = CsvReader(CsvReaderConfig(skipEmptyLine = true))
+        reader.readAll(ByteArrayInputStream(raw)) shouldBe listOf(listOf("a", "b"), listOf("c", "d"))
+    }
+
+    @Test
+    fun readAll_stream_inputLargerThanBufferSize_forcesChunkBoundarySwap() {
+        // 8 KB is the default chunk size in parseRowsFromChunks. Pump well past
+        // that so the double-buffer swap and cross-chunk lookahead paths run.
+        val cellsPerRow = 4
+        val rowCount = 3_000
+        val csv = buildString {
+            repeat(rowCount) { row ->
+                (0 until cellsPerRow).joinTo(this, separator = ",") { col -> "r${row}c${col}" }
+                append('\n')
+            }
+        }
+        val rows = CsvReader().readAll(ByteArrayInputStream(csv.toByteArray(Charsets.UTF_8)))
+        rows.size shouldBe rowCount
+        rows.first() shouldBe listOf("r0c0", "r0c1", "r0c2", "r0c3")
+        rows.last() shouldBe listOf("r${rowCount - 1}c0", "r${rowCount - 1}c1", "r${rowCount - 1}c2", "r${rowCount - 1}c3")
+    }
 }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.reader
 
 import io.kotest.matchers.shouldBe
+import kotlinx.io.files.Path as KxPath
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
@@ -17,6 +18,43 @@ class CsvReaderPathSmokeTest {
             val reader = CsvReader()
             val rows = reader.readFromFile(tmp.toString()) { seq -> seq.toList() }
             rows shouldBe listOf(listOf("a", "b", "c"), listOf("d", "e", "f"))
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun readFromFile_kotlinxIoPath_defaultOptions_decodesRows() {
+        // Direct call into the kotlinx-io Path overloads with options omitted,
+        // covering the default-argument synthetic methods on readFromFile and
+        // readAllFromFile.
+        val tmp = Files.createTempFile("kotlin-csv-reader-smoke-defaults", ".csv")
+        try {
+            Files.writeString(tmp, "a,b\nc,d")
+            val path = KxPath(tmp.toString())
+            CsvReader().readFromFile(path) { it.toList() } shouldBe listOf(listOf("a", "b"), listOf("c", "d"))
+            CsvReader().readAllFromFile(path) shouldBe listOf(listOf("a", "b"), listOf("c", "d"))
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun readFromFile_stringPath_inputLargerThanChunkBuffer_drivesKotlinxIoLimitBranch() {
+        // The kotlinx-io chunk reader stops one slot before the buffer end, so
+        // it has to exit on `index >= limit` at least once. Default buffer is
+        // 8 KB; pump well past that to take the limit branch on a real file.
+        val tmp = Files.createTempFile("kotlin-csv-reader-smoke-large", ".csv")
+        try {
+            val rowCount = 3_000
+            val csv = buildString {
+                repeat(rowCount) { row -> append("r$row,col1,col2,col3\n") }
+            }
+            Files.writeString(tmp, csv)
+            val rows = CsvReader().readFromFile(tmp.toString()) { seq -> seq.toList() }
+            rows.size shouldBe rowCount
+            rows.first() shouldBe listOf("r0", "col1", "col2", "col3")
+            rows.last() shouldBe listOf("r${rowCount - 1}", "col1", "col2", "col3")
         } finally {
             tmp.deleteIfExists()
         }


### PR DESCRIPTION
## Summary
- keep the public lazy `Sequence<Char>` reader API intact
- add a chunked reader fast path that walks an 8 KB `CharArray` buffer directly with double buffering for next-char lookahead
- route JVM `read(InputStream)` / `readFromFile(File)` and kotlinx-io `read(Source)` through the chunked path
- add `ParseStateMachine.reset()` so the state machine, `StringBuilder`, and `fields` ArrayList are reused across rows
- extract `CsvReader.applyPipeline` so I/O wrappers can attach `skipEmptyLine` + field-count policy without rerouting chars through a `Sequence<Char>`

## Verification
- [x] `./gradlew check`
- [x] `benchmark/parity` row-by-row HARD equivalence test passes

## Benchmark results

Measured on the same machine as issue #172 (Apple M4 / 32 GB / JDK 21.0.6 / JMH 1.36, seed=42), `primary` profile (warmup=5 / iter=5 / fork=2 / 10s).

- **Before** = v2.0.0 primary numbers from [issue #172 primary comment](https://github.com/jsoizo/kotlin-csv/issues/172#issuecomment-4472909584) (commit `7fe79b4`). Reader sources between `7fe79b4` and this branch are touched only by this PR (`ParseStateMachine.kt`, `SequenceParser.kt`, `CsvReader.kt`, `ReaderIo.kt`, `ReaderIoJvm.kt`), so the issue numbers are a valid Before for the reader workloads.
- **After** = this PR (`cdf3284`), measured 2026-05-22.

### Throughput (ops/ms, higher is better)

I/O paths (the workloads that drove the issue's long-tail divergence):

| Workload | Dataset | Before | After | Delta | vs v1.10.0 |
|---|---:|---:|---:|---:|---:|
| `readAll(InputStream)` | SMALL | 0.7669 | **1.5104 ± 0.0121** | **+97%** (1.97×) | **1.82× faster** |
| `readAll(InputStream)` | MEDIUM | 0.00407 | **0.00772 ± 0.00005** | **+90%** (1.90×) | **1.82× faster** |
| `readAll(InputStream)` | HARD | 0.0538 | **0.0979 ± 0.0016** | **+82%** (1.82×) | **1.97× faster** |
| `readAll(File)` | SMALL | 0.7372 | **1.3543 ± 0.0280** | **+84%** (1.84×) | **1.68× faster** |
| `readAll(File)` | MEDIUM | 0.00377 | **0.00740 ± 0.00010** | **+96%** (1.96×) | **1.85× faster** |
| `readAll(File)` | HARD | 0.0554 | **0.0922 ± 0.0009** | **+66%** (1.66×) | **1.91× faster** |
| `open(file){ asSequence().count() }` | SMALL | 0.7427 | **1.4280 ± 0.0134** | **+92%** (1.92×) | **1.76× faster** |
| `open(file){ asSequence().count() }` | MEDIUM | 0.00375 | **0.00756 ± 0.00011** | **+102%** (2.02×) | **1.84× faster** |
| `open(file){ asSequence().count() }` | HARD | 0.0544 | **0.0872 ± 0.0058** | **+60%** (1.60×) | **1.78× faster** |

String paths (already v2-favoured; included for completeness):

| Workload | Dataset | Before | After | Delta | vs v1.10.0 |
|---|---:|---:|---:|---:|---:|
| `readAll(String)` | SMALL | 1.6116 | 1.7019 ± 0.0125 | +6% | 2.04× faster |
| `readAll(String)` | MEDIUM | 0.00819 | 0.00855 ± 0.00021 | +4% | 2.10× faster |
| `readAll(String)` | HARD | 0.1115 | 0.1154 ± 0.0011 | +3% | 2.45× faster |
| `readAllWithHeader(String)` | SMALL | 1.4490 | 1.4944 ± 0.0665 | +3% | 1.94× faster |
| `readAllWithHeader(String)` | MEDIUM | 0.00654 | 0.00708 ± 0.00012 | +8% | 1.85× faster |
| `readAllWithHeader(String)` | HARD | 0.0969 | 0.1019 ± 0.0054 | +5% | 2.28× faster |

### Average time (ms/op, lower is better)

I/O paths (Before suffered the long-tail outliers — `thrpt × avgt ≈ 3`):

| Workload | Dataset | Before | After | Delta |
|---|---:|---:|---:|---:|
| `readAll(InputStream)` | SMALL | 5.12 | **0.676 ± 0.017** | **7.6× faster** |
| `readAll(InputStream)` | MEDIUM | 947.30 | **129.59 ± 2.69** | **7.3× faster** |
| `readAll(InputStream)` | HARD | 57.56 | **10.23 ± 0.25** | **5.6× faster** |
| `readAll(File)` | SMALL | 4.53 | **0.718 ± 0.020** | **6.3× faster** |
| `readAll(File)` | MEDIUM | 876.29 | **134.31 ± 2.64** | **6.5× faster** |
| `readAll(File)` | HARD | 71.47 | **11.09 ± 0.30** | **6.4× faster** |
| `open(file){ asSequence().count() }` | SMALL | 3.56 | **0.736 ± 0.048** | **4.8× faster** |
| `open(file){ asSequence().count() }` | MEDIUM | 557.28 | **143.61 ± 8.90** | **3.9× faster** |
| `open(file){ asSequence().count() }` | HARD | 27.93 | **11.25 ± 0.36** | **2.5× faster** |

### Notes

- The avgt × thrpt divergence flagged in the issue's primary comment for reader I/O workloads (`thrpt × avgt ≈ 3` on Before) is resolved on After. Examples: `readAll(InputStream)` MEDIUM `0.00772 × 129.59 ≈ 1.00`, `readAll(File)` MEDIUM `0.00740 × 134.31 ≈ 0.99`. Long-tail Continuation allocations from the per-char `sequence { yield(c) }` are gone.
- Score errors shrank substantially (e.g. `readAll(File)` MEDIUM: Before `876.29 ± 158.70 ms/op` ≈ 18% noise → After `134.31 ± 2.64` ≈ 2%), consistent with the parser no longer producing GC-driven outliers.
- String paths were already v2-favoured (no per-char yield — JDK's `String.asSequence()` iterator does not allocate Continuations). The chunked path is a small additional win (+3–8%) but there was no long-tail there to begin with.
- `gc.alloc.rate.norm` (B/op) still sits at v1×1.30–1.36 on I/O paths after this PR — this is the structural per-row allocation (e.g. `ArrayList.toList()` copies, `InputStreamReader` internal char buffer) that does not produce long-tails. Tracked as a follow-up for v2.0.x; not a blocker for the long-tail goal of this PR.
- kotlinx-io vs java.io reader paths sit at ~7–13% CPU overhead with `alloc/op` parity after this PR. Tracked as a follow-up; not addressed here.

### Reproduction

\`\`\`bash
./gradlew :benchmark:v2:jmh -Pbench.profile=primary -Pjmh.include='.*ReadBenchmarksV2.*'
\`\`\`