### PR TITLE
Add nullable CSV field APIs

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -39,7 +39,9 @@ same instance are independent and can proceed concurrently.
 The core APIs operate on `Sequence`:
 
 - Reader: `Sequence<Char>` to `Sequence<List<String>>`
+- Nullable reader: `Sequence<Char>` to `Sequence<List<String?>>`
 - Writer: `Sequence<List<String>>` to `Sequence<Char>`
+- Nullable writer: `Sequence<List<String?>>` to `Sequence<Char>`
 
 The returned sequences are **cold**. No work happens until a terminal
 operation (`forEach`, `toList`, `first`, `take(n).toList()`, ...) pulls the
@@ -113,6 +115,11 @@ sequence is built.
 The eager wrapper `CsvReader.readAll(text)` parses the whole input up-front
 and returns a `List<List<String>>`. Exceptions propagate from the call site.
 
+Nullable counterparts (`readNullable`, `readAllNullable`, and nullable I/O
+overloads) return `String?` fields. [CsvReaderConfig.nullFieldIndicator]
+controls whether quoted empty fields, unquoted empty fields, both, or neither
+are exposed as `null`.
+
 ## Field-count policies
 
 The first row sets the expected field count for the rest of the input. Two
@@ -132,6 +139,9 @@ field-count check. When `ERROR` raises `CsvFieldNumDifferentException`,
 `rowNum` counts the CSV rows that remain after this filter; it is not a
 physical source line number.
 
+For nullable reads, `EMPTY_STRING` padding from the insufficient-field policy
+is still an empty string, not `null`.
+
 ## Header processing
 
 Header support is not part of the reader core; it is provided as the
@@ -141,6 +151,11 @@ header order at the type level. Duplicate headers either throw
 [com.jsoizo.kotlincsv.exceptions.MalformedCsvException] (default) or are
 deterministically renamed with `_2`, `_3`, ... suffixes when
 `autoRenameDuplicateHeaders = true`.
+
+Nullable header support is provided by [Sequence.withNullableHeader]. Header
+keys remain non-null `String` values because they are column names. A `null`
+header field is normalized to the empty header name `""`; data values remain
+nullable.
 
 ## I/O-layer behaviour
 
@@ -189,6 +204,11 @@ ultimately consumes the characters.
 
 The eager wrapper `CsvWriter.writeAll(rows)` joins the encoded characters
 into a single `String`.
+
+Nullable counterparts (`writeNullable`, `writeAllNullable`, and nullable I/O
+overloads) emit `null` fields as unquoted empty fields. Non-null strings use
+the same quote and escape rules as the regular writer. Use `quoteMode = ALL`
+when you need the output to distinguish `null` from an empty string.
 
 ## Quote modes
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ share them across calls.
 ```kotlin
 import com.jsoizo.kotlincsv.csvReader
 import com.jsoizo.kotlincsv.csvWriter
+import com.jsoizo.kotlincsv.reader.CsvNullFieldIndicator
 import com.jsoizo.kotlincsv.reader.readFromFile
 import com.jsoizo.kotlincsv.reader.withHeader
+import com.jsoizo.kotlincsv.writer.WriteQuoteMode
 import com.jsoizo.kotlincsv.writer.writeToFile
 
 val reader = csvReader()
@@ -114,6 +116,11 @@ reader.readFromFile(File("data.csv")) { rows ->
     val records = rows.withHeader().toList()
     println(records.first()["id"])
 }
+
+// Nullable reads can distinguish "" from an unquoted empty field.
+val nullableRows = csvReader {
+    nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS
+}.readAllNullable("\"empty\",\"null\"\n\"\",")
 ```
 
 `reader.readFromFile(...)` accepts `String` paths, `kotlinx.io.files.Path`,
@@ -136,6 +143,11 @@ val csv: String = writer.writeAll(rows)
 
 // To a File
 writer.writeToFile(rows, File("out.csv"))
+
+// Nullable writes emit null as an unquoted empty field.
+val nullableCsv = csvWriter {
+    quoteMode = WriteQuoteMode.ALL
+}.writeAllNullable(listOf(listOf(null, "", "value")))
 ```
 
 `writer.writeToFile(...)` accepts `String` paths, `kotlinx.io.files.Path`,
@@ -170,9 +182,15 @@ val customWriter = csvWriter {
 | `skipEmptyLine` | `false` | Drop rows that are entirely empty before the field-count check. |
 | `excessFieldsRowBehaviour` | `ERROR` | What to do when a row has more fields than the first row: `ERROR` / `IGNORE` / `TRIM`. |
 | `insufficientFieldsRowBehaviour` | `ERROR` | What to do when a row has fewer fields: `ERROR` / `IGNORE` / `EMPTY_STRING`. |
+| `nullFieldIndicator` | `NEITHER` | Which empty fields nullable reader APIs expose as `null`: `NEITHER` / `EMPTY_SEPARATORS` / `EMPTY_QUOTES` / `BOTH`. |
 
 `CsvFieldNumDifferentException.rowNum` counts CSV rows after reader filters
 such as `skipEmptyLine`; it is not a physical source line number.
+
+Nullable reader APIs (`readNullable`, `readAllNullable`, and nullable I/O
+overloads) return `String?` values. `withNullableHeader()` keeps header keys
+as non-null `String`; a null-looking empty header is treated as the empty
+header name `""`, while data values remain nullable.
 
 | Writer option | Default | Description |
 | --- | --- | --- |

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvHeader.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvHeader.kt
@@ -38,6 +38,38 @@ fun Sequence<List<String>>.withHeader(
     }
 }
 
+/**
+ * Treat the first nullable row as a non-null header and zip subsequent rows
+ * into [LinkedHashMap]s keyed by the header values.
+ *
+ * Header values are column names, so `null` header fields are normalized to
+ * empty headers (`""`). Duplicate handling matches [withHeader].
+ */
+fun Sequence<List<String?>>.withNullableHeader(
+    autoRenameDuplicateHeaders: Boolean = false,
+): Sequence<LinkedHashMap<String, String?>> = sequence {
+    val iter = iterator()
+    if (!iter.hasNext()) return@sequence
+
+    val rawHeader = iter.next().map { it ?: "" }
+    val header = if (autoRenameDuplicateHeaders) {
+        renameDuplicates(rawHeader)
+    } else {
+        ensureUnique(rawHeader)
+        rawHeader
+    }
+
+    while (iter.hasNext()) {
+        val row = iter.next()
+        val map = LinkedHashMap<String, String?>(header.size)
+        val limit = minOf(header.size, row.size)
+        for (i in 0 until limit) {
+            map[header[i]] = row[i]
+        }
+        yield(map)
+    }
+}
+
 private fun ensureUnique(header: List<String>) {
     val seen = mutableSetOf<String>()
     for (h in header) {

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvNullFieldIndicator.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvNullFieldIndicator.kt
@@ -1,0 +1,16 @@
+package com.jsoizo.kotlincsv.reader
+
+/** Controls which empty CSV fields are exposed as `null` by nullable reader APIs. */
+enum class CsvNullFieldIndicator {
+    /** Treat quoted and unquoted empty fields as empty strings. */
+    NEITHER,
+
+    /** Treat unquoted empty fields as `null`. */
+    EMPTY_SEPARATORS,
+
+    /** Treat quoted empty fields as `null`. */
+    EMPTY_QUOTES,
+
+    /** Treat both quoted and unquoted empty fields as `null`. */
+    BOTH
+}

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReader.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReader.kt
@@ -2,7 +2,9 @@ package com.jsoizo.kotlincsv.reader
 
 import com.jsoizo.kotlincsv.exceptions.CsvFieldNumDifferentException
 import com.jsoizo.kotlincsv.exceptions.CsvParseFormatException
+import com.jsoizo.kotlincsv.reader.internal.ParsedCsvField
 import com.jsoizo.kotlincsv.reader.internal.parseRows
+import com.jsoizo.kotlincsv.reader.internal.parseRowsWithMetadata
 
 /**
  * Stateless CSV reader. [read] is the lazy core API; [readAll] is the eager
@@ -27,6 +29,16 @@ class CsvReader(val config: CsvReaderConfig = CsvReaderConfig()) {
     fun readAll(text: String): List<List<String>> = read(text.asSequence()).toList()
 
     /**
+     * Parse [chars] into nullable rows. Empty-field null mapping is controlled
+     * by [CsvReaderConfig.nullFieldIndicator].
+     */
+    fun readNullable(chars: Sequence<Char>): Sequence<List<String?>> =
+        applyNullablePipeline(parseRowsWithMetadata(chars, config.dialect))
+
+    /** Eagerly parse [text] into a list of nullable rows. */
+    fun readAllNullable(text: String): List<List<String?>> = readNullable(text.asSequence()).toList()
+
+    /**
      * Apply skipEmptyLine filter and field-count policy to a parsed row
      * sequence. Used by I/O wrappers that obtain rows from chunked parsers
      * without routing chars through a `Sequence<Char>`.
@@ -40,8 +52,34 @@ class CsvReader(val config: CsvReaderConfig = CsvReaderConfig()) {
         return applyFieldCountPolicy(filtered)
     }
 
+    internal fun applyNullablePipeline(parsed: Sequence<List<ParsedCsvField>>): Sequence<List<String?>> {
+        val filtered = if (config.skipEmptyLine) {
+            parsed.filter { row -> !isEmptyParsedRow(row) }
+        } else {
+            parsed
+        }
+        return applyNullableFieldCountPolicy(
+            filtered.map { row ->
+                row.map { field -> field.toNullable(config.nullFieldIndicator) }
+            }
+        )
+    }
+
     private fun isEmptyRow(row: List<String>): Boolean =
         row.isEmpty() || (row.size == 1 && row.single().isBlank())
+
+    private fun isEmptyParsedRow(row: List<ParsedCsvField>): Boolean =
+        row.isEmpty() || (row.size == 1 && row.single().value.isBlank())
+
+    private fun ParsedCsvField.toNullable(indicator: CsvNullFieldIndicator): String? {
+        if (value.isNotEmpty()) return value
+        return when (indicator) {
+            CsvNullFieldIndicator.NEITHER -> value
+            CsvNullFieldIndicator.EMPTY_SEPARATORS -> if (quoted) value else null
+            CsvNullFieldIndicator.EMPTY_QUOTES -> if (quoted) null else value
+            CsvNullFieldIndicator.BOTH -> null
+        }
+    }
 
     private fun applyFieldCountPolicy(rows: Sequence<List<String>>): Sequence<List<String>> = sequence {
         var expected: Int? = null
@@ -76,6 +114,45 @@ class CsvReader(val config: CsvReaderConfig = CsvReaderConfig()) {
 
                     InsufficientFieldsRowBehaviour.EMPTY_STRING ->
                         yield(row + List(current - row.size) { "" })
+                }
+
+                else -> yield(row)
+            }
+        }
+    }
+
+    private fun applyNullableFieldCountPolicy(rows: Sequence<List<String?>>): Sequence<List<String?>> = sequence {
+        var expected: Int? = null
+        var rowNum = 0L
+        for (row in rows) {
+            rowNum++
+            val current = expected
+            if (current == null) {
+                expected = row.size
+                yield(row)
+                continue
+            }
+            when {
+                row.size > current -> when (config.excessFieldsRowBehaviour) {
+                    ExcessFieldsRowBehaviour.ERROR ->
+                        throw CsvFieldNumDifferentException(current, row.size, rowNum)
+
+                    ExcessFieldsRowBehaviour.IGNORE ->
+                        Unit
+
+                    ExcessFieldsRowBehaviour.TRIM ->
+                        yield(row.subList(0, current))
+                }
+
+                row.size < current -> when (config.insufficientFieldsRowBehaviour) {
+                    InsufficientFieldsRowBehaviour.ERROR ->
+                        throw CsvFieldNumDifferentException(current, row.size, rowNum)
+
+                    InsufficientFieldsRowBehaviour.IGNORE ->
+                        Unit
+
+                    InsufficientFieldsRowBehaviour.EMPTY_STRING ->
+                        yield(row + List<String?>(current - row.size) { "" })
                 }
 
                 else -> yield(row)

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderConfig.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderConfig.kt
@@ -12,10 +12,13 @@ import com.jsoizo.kotlincsv.CsvDialect
  *   fields than the first row. Defaults to [InsufficientFieldsRowBehaviour.ERROR].
  * @property excessFieldsRowBehaviour Strategy for rows with more fields than
  *   the first row. Defaults to [ExcessFieldsRowBehaviour.ERROR].
+ * @property nullFieldIndicator Which empty fields nullable reader APIs expose
+ *   as `null`. Defaults to [CsvNullFieldIndicator.NEITHER].
  */
 data class CsvReaderConfig(
     val dialect: CsvDialect = CsvDialect.RFC4180,
     val skipEmptyLine: Boolean = false,
     val insufficientFieldsRowBehaviour: InsufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.ERROR,
     val excessFieldsRowBehaviour: ExcessFieldsRowBehaviour = ExcessFieldsRowBehaviour.ERROR,
+    val nullFieldIndicator: CsvNullFieldIndicator = CsvNullFieldIndicator.NEITHER,
 )

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderConfigBuilder.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderConfigBuilder.kt
@@ -14,11 +14,13 @@ class CsvReaderConfigBuilder internal constructor() {
         InsufficientFieldsRowBehaviour.ERROR
     var excessFieldsRowBehaviour: ExcessFieldsRowBehaviour =
         ExcessFieldsRowBehaviour.ERROR
+    var nullFieldIndicator: CsvNullFieldIndicator = CsvNullFieldIndicator.NEITHER
 
     internal fun build(): CsvReaderConfig = CsvReaderConfig(
         dialect = dialect,
         skipEmptyLine = skipEmptyLine,
         insufficientFieldsRowBehaviour = insufficientFieldsRowBehaviour,
         excessFieldsRowBehaviour = excessFieldsRowBehaviour,
+        nullFieldIndicator = nullFieldIndicator,
     )
 }

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIo.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIo.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.reader
 
 import com.jsoizo.kotlincsv.reader.internal.parseRowsFromChunks
+import com.jsoizo.kotlincsv.reader.internal.parseRowsWithMetadataFromChunks
 import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -31,6 +32,25 @@ fun CsvReader.readAll(
     source: Source,
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = read(source, options) { it.toList() }
+
+/**
+ * Read nullable CSV rows from [source] (UTF-8) and pass them to [block].
+ * [source] is caller-owned and is not closed by this call.
+ */
+fun <T> CsvReader.readNullable(
+    source: Source,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+    block: (Sequence<List<String?>>) -> T,
+): T {
+    val parsed = parseRowsWithMetadataFromChunks(source.asChunkReader(), config.dialect, options.stripBom)
+    return block(applyNullablePipeline(parsed))
+}
+
+/** Eagerly read all nullable CSV rows from [source] (UTF-8). */
+fun CsvReader.readAllNullable(
+    source: Source,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+): List<List<String?>> = readNullable(source, options) { it.toList() }
 
 private fun Source.asChunkReader(): (CharArray) -> Int = { buffer ->
     var index = 0
@@ -72,6 +92,24 @@ fun CsvReader.readAllFromFile(
 ): List<List<String>> = readFromFile(path, options) { it.toList() }
 
 /**
+ * Read nullable CSV rows from the file at [path] (UTF-8) and pass them to
+ * [block]. The underlying source is closed when [block] returns or throws.
+ */
+fun <T> CsvReader.readNullableFromFile(
+    path: Path,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+    block: (Sequence<List<String?>>) -> T,
+): T = SystemFileSystem.source(path).buffered().use { bufferedSource ->
+    readNullable(bufferedSource, options, block)
+}
+
+/** Eagerly read all nullable CSV rows from the file at [path] (UTF-8). */
+fun CsvReader.readAllNullableFromFile(
+    path: Path,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+): List<List<String?>> = readNullableFromFile(path, options) { it.toList() }
+
+/**
  * String-path overload of [readFromFile]. The `Sequence` passed to [block]
  * must be consumed inside the block.
  */
@@ -86,3 +124,19 @@ fun CsvReader.readAllFromFile(
     filePath: String,
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = readFromFile(filePath, options) { it.toList() }
+
+/**
+ * String-path overload of [readNullableFromFile]. The `Sequence` passed to
+ * [block] must be consumed inside the block.
+ */
+fun <T> CsvReader.readNullableFromFile(
+    filePath: String,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+    block: (Sequence<List<String?>>) -> T,
+): T = readNullableFromFile(Path(filePath), options, block)
+
+/** String-path overload of [readAllNullableFromFile]. */
+fun CsvReader.readAllNullableFromFile(
+    filePath: String,
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+): List<List<String?>> = readNullableFromFile(filePath, options) { it.toList() }

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/ParseStateMachine.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/ParseStateMachine.kt
@@ -2,6 +2,11 @@ package com.jsoizo.kotlincsv.reader.internal
 
 import com.jsoizo.kotlincsv.exceptions.CsvParseFormatException
 
+internal data class ParsedCsvField(
+    val value: String,
+    val quoted: Boolean
+)
+
 internal class ParseStateMachine(
     private val quoteChar: Char,
     private val delimiter: Char,
@@ -10,9 +15,11 @@ internal class ParseStateMachine(
 
     private var state = ParseState.START
 
-    private val fields = ArrayList<String>()
+    private val fields = ArrayList<ParsedCsvField>()
 
     private var field = StringBuilder()
+
+    private var currentFieldQuoted = false
 
     private var pos = 0L
 
@@ -22,7 +29,10 @@ internal class ParseStateMachine(
         when (state) {
             ParseState.START -> {
                 when (ch) {
-                    quoteChar -> state = ParseState.QUOTE_START
+                    quoteChar -> {
+                        currentFieldQuoted = true
+                        state = ParseState.QUOTE_START
+                    }
                     // When `escapeChar == quoteChar`, the quoteChar arm above wins; this arm is unreachable.
                     escapeChar -> state = handleUnquotedEscape(nextCh, rowNum)
                     delimiter -> {
@@ -70,7 +80,10 @@ internal class ParseStateMachine(
             }
             ParseState.DELIMITER -> {
                 when (ch) {
-                    quoteChar -> state = ParseState.QUOTE_START
+                    quoteChar -> {
+                        currentFieldQuoted = true
+                        state = ParseState.QUOTE_START
+                    }
                     // When `escapeChar == quoteChar`, the quoteChar arm above wins; this arm is unreachable.
                     escapeChar -> state = handleUnquotedEscape(nextCh, rowNum)
                     delimiter -> {
@@ -159,25 +172,26 @@ internal class ParseStateMachine(
         state = ParseState.START
         fields.clear()
         field.clear()
+        currentFieldQuoted = false
         pos = 0L
     }
 
-    fun finishRow(): List<String>? {
+    fun finishRow(): List<ParsedCsvField>? {
         return when (state) {
             ParseState.DELIMITER -> {
-                fields.add("")
+                fields.add(ParsedCsvField("", quoted = false))
                 fields.toList()
             }
             ParseState.QUOTED_FIELD -> null
             ParseState.FIELD, ParseState.QUOTE_END -> {
-                fields.add(field.toString())
+                fields.add(ParsedCsvField(field.toString(), currentFieldQuoted))
                 fields.toList()
             }
             else -> fields.toList()
         }
     }
 
-    fun finishFinalRow(rowNum: Long): List<String>? {
+    fun finishFinalRow(rowNum: Long): List<ParsedCsvField>? {
         if (state == ParseState.QUOTE_START || state == ParseState.QUOTED_FIELD) {
             throw CsvParseFormatException(rowNum, pos, quoteChar, "end of quote doesn't exist")
         }
@@ -185,8 +199,9 @@ internal class ParseStateMachine(
     }
 
     private fun flushField() {
-        fields.add(field.toString())
+        fields.add(ParsedCsvField(field.toString(), currentFieldQuoted))
         field.clear()
+        currentFieldQuoted = false
     }
 
     /**

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParser.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/reader/internal/SequenceParser.kt
@@ -8,7 +8,14 @@ private const val BOM_CHAR = '\uFEFF'
 internal fun parseRows(
     chars: Sequence<Char>,
     dialect: CsvDialect,
-): Sequence<List<String>> = sequence {
+): Sequence<List<String>> =
+    parseRowsWithMetadata(chars, dialect).map { row -> row.map { it.value } }
+
+/** Lazily parse a `Sequence<Char>` into CSV rows with quoted-field metadata. */
+internal fun parseRowsWithMetadata(
+    chars: Sequence<Char>,
+    dialect: CsvDialect,
+): Sequence<List<ParsedCsvField>> = sequence {
     val iter = chars.iterator()
     if (!iter.hasNext()) return@sequence
 
@@ -68,7 +75,16 @@ internal fun parseRowsFromChunks(
     dialect: CsvDialect,
     stripBom: Boolean = false,
     bufferSize: Int = 8192,
-): Sequence<List<String>> = sequence {
+): Sequence<List<String>> =
+    parseRowsWithMetadataFromChunks(readInto, dialect, stripBom, bufferSize).map { row -> row.map { it.value } }
+
+/** Lazily parse chunked CSV rows with quoted-field metadata. */
+internal fun parseRowsWithMetadataFromChunks(
+    readInto: (CharArray) -> Int,
+    dialect: CsvDialect,
+    stripBom: Boolean = false,
+    bufferSize: Int = 8192,
+): Sequence<List<ParsedCsvField>> = sequence {
     require(bufferSize >= 2) { "bufferSize must be >= 2 to hold a UTF-16 surrogate pair" }
 
     val bufferA = CharArray(bufferSize)

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/CsvWriter.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/CsvWriter.kt
@@ -1,7 +1,9 @@
 package com.jsoizo.kotlincsv.writer
 
 import com.jsoizo.kotlincsv.writer.internal.appendRows
+import com.jsoizo.kotlincsv.writer.internal.appendNullableRows
 import com.jsoizo.kotlincsv.writer.internal.encodeRows
+import com.jsoizo.kotlincsv.writer.internal.encodeNullableRows
 
 /**
  * Stateless CSV writer. [write] is the lazy core API; [writeAll] is the
@@ -15,5 +17,13 @@ class CsvWriter(val config: CsvWriterConfig = CsvWriterConfig()) {
     /** Eagerly encode [rows] into a single CSV string. */
     fun writeAll(rows: List<List<String>>): String = buildString {
         appendRows(rows.asSequence(), config, this)
+    }
+
+    /** Encode nullable [rows]. Null fields are emitted as unquoted empty fields. */
+    fun writeNullable(rows: Sequence<List<String?>>): Sequence<Char> = encodeNullableRows(rows, config)
+
+    /** Eagerly encode nullable [rows] into a single CSV string. */
+    fun writeAllNullable(rows: List<List<String?>>): String = buildString {
+        appendNullableRows(rows.asSequence(), config, this)
     }
 }

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIo.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIo.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.writer
 
 import com.jsoizo.kotlincsv.writer.internal.appendRows
+import com.jsoizo.kotlincsv.writer.internal.appendNullableRows
 import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -37,6 +38,31 @@ fun CsvWriter.write(
 ) = write(rows.asSequence(), sink, options)
 
 /**
+ * Encode nullable [rows] and write to [sink] as UTF-8. Null fields are emitted
+ * as unquoted empty fields.
+ */
+fun CsvWriter.writeNullable(
+    rows: Sequence<List<String?>>,
+    sink: Sink,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) {
+    if (options.prependBom) {
+        sink.writeString(BOM_STRING)
+    }
+    val out = SinkAppendable(sink)
+    appendNullableRows(rows, config, out)
+    out.flush()
+    sink.flush()
+}
+
+/** @see writeNullable */
+fun CsvWriter.writeNullable(
+    rows: List<List<String?>>,
+    sink: Sink,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullable(rows.asSequence(), sink, options)
+
+/**
  * Encode [rows] and write to the file at [path] as UTF-8. The file is
  * truncated, written, flushed and closed inside this call.
  */
@@ -57,6 +83,27 @@ fun CsvWriter.writeToFile(
     options: CsvWriteIoOptions = CsvWriteIoOptions(),
 ) = writeToFile(rows.asSequence(), path, options)
 
+/**
+ * Encode nullable [rows] and write to the file at [path] as UTF-8. The file is
+ * truncated, written, flushed and closed inside this call.
+ */
+fun CsvWriter.writeNullableToFile(
+    rows: Sequence<List<String?>>,
+    path: Path,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) {
+    SystemFileSystem.sink(path).buffered().use { bufferedSink ->
+        writeNullable(rows, bufferedSink, options)
+    }
+}
+
+/** @see writeNullableToFile */
+fun CsvWriter.writeNullableToFile(
+    rows: List<List<String?>>,
+    path: Path,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullableToFile(rows.asSequence(), path, options)
+
 /** String-path overload of [writeToFile]. */
 fun CsvWriter.writeToFile(
     rows: Sequence<List<String>>,
@@ -70,6 +117,20 @@ fun CsvWriter.writeToFile(
     filePath: String,
     options: CsvWriteIoOptions = CsvWriteIoOptions(),
 ) = writeToFile(rows.asSequence(), filePath, options)
+
+/** String-path overload of [writeNullableToFile]. */
+fun CsvWriter.writeNullableToFile(
+    rows: Sequence<List<String?>>,
+    filePath: String,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullableToFile(rows, Path(filePath), options)
+
+/** @see writeNullableToFile */
+fun CsvWriter.writeNullableToFile(
+    rows: List<List<String?>>,
+    filePath: String,
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullableToFile(rows.asSequence(), filePath, options)
 
 private class SinkAppendable(
     private val sink: Sink,

--- a/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/internal/SequenceEncoder.kt
+++ b/src/commonMain/kotlin/com/jsoizo/kotlincsv/writer/internal/SequenceEncoder.kt
@@ -27,6 +27,26 @@ internal fun encodeRows(
     }
 }
 
+/** Lazily encode nullable CSV rows. Null fields are emitted as unquoted empty fields. */
+internal fun encodeNullableRows(
+    rows: Sequence<List<String?>>,
+    config: CsvWriterConfig,
+): Sequence<Char> = sequence {
+    val dialect = config.dialect
+    val lineTerminator = dialect.lineTerminator
+    val iter = rows.iterator()
+    if (!iter.hasNext()) return@sequence
+
+    yieldAll(encodeNullableRow(iter.next(), dialect, config.quoteMode))
+    while (iter.hasNext()) {
+        yieldAll(lineTerminator.asSequence())
+        yieldAll(encodeNullableRow(iter.next(), dialect, config.quoteMode))
+    }
+    if (config.outputLastLineTerminator) {
+        yieldAll(lineTerminator.asSequence())
+    }
+}
+
 /**
  * Eagerly encode [rows] into [out] without routing every character through a
  * `Sequence<Char>`. Used by String and I/O writers; [encodeRows] remains the
@@ -52,6 +72,30 @@ internal fun appendRows(
     }
 }
 
+/**
+ * Eagerly encode nullable [rows] into [out]. Null fields are emitted as
+ * unquoted empty fields.
+ */
+internal fun appendNullableRows(
+    rows: Sequence<List<String?>>,
+    config: CsvWriterConfig,
+    out: Appendable,
+) {
+    val dialect = config.dialect
+    val lineTerminator = dialect.lineTerminator
+    val iter = rows.iterator()
+    if (!iter.hasNext()) return
+
+    appendNullableRow(iter.next(), dialect, config.quoteMode, out)
+    while (iter.hasNext()) {
+        out.append(lineTerminator)
+        appendNullableRow(iter.next(), dialect, config.quoteMode, out)
+    }
+    if (config.outputLastLineTerminator) {
+        out.append(lineTerminator)
+    }
+}
+
 private fun encodeRow(
     row: List<String>,
     dialect: CsvDialect,
@@ -62,6 +106,22 @@ private fun encodeRow(
     for (field in row) {
         if (!first) yield(delimiter)
         yieldAll(encodeField(field, dialect, quoteMode))
+        first = false
+    }
+}
+
+private fun encodeNullableRow(
+    row: List<String?>,
+    dialect: CsvDialect,
+    quoteMode: WriteQuoteMode,
+): Sequence<Char> = sequence {
+    val delimiter = dialect.delimiter
+    var first = true
+    for (field in row) {
+        if (!first) yield(delimiter)
+        if (field != null) {
+            yieldAll(encodeField(field, dialect, quoteMode))
+        }
         first = false
     }
 }
@@ -77,6 +137,23 @@ private fun appendRow(
     for (field in row) {
         if (!first) out.append(delimiter)
         appendField(field, dialect, quoteMode, out)
+        first = false
+    }
+}
+
+private fun appendNullableRow(
+    row: List<String?>,
+    dialect: CsvDialect,
+    quoteMode: WriteQuoteMode,
+    out: Appendable,
+) {
+    val delimiter = dialect.delimiter
+    var first = true
+    for (field in row) {
+        if (!first) out.append(delimiter)
+        if (field != null) {
+            appendField(field, dialect, quoteMode, out)
+        }
         first = false
     }
 }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvHeaderTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvHeaderTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.Test
 class CsvHeaderTest {
 
     private fun seq(vararg rows: List<String>): Sequence<List<String>> = rows.asSequence()
+    private fun nullableSeq(vararg rows: List<String?>): Sequence<List<String?>> = rows.asSequence()
 
     @Test
     fun basic_zipsHeaderWithRows() {
@@ -118,5 +119,47 @@ class CsvHeaderTest {
         ).withHeader().toList()
 
         result.single().keys.toList() shouldBe listOf("z", "y", "x")
+    }
+
+    @Test
+    fun nullableHeader_zipsHeaderWithNullableRows() {
+        val result = nullableSeq(
+            listOf("a", "b", "c"),
+            listOf("1", null, ""),
+        ).withNullableHeader().toList()
+
+        result.single() shouldBe linkedMapOf("a" to "1", "b" to null, "c" to "")
+    }
+
+    @Test
+    fun nullableHeader_nullHeaderIsEmptyHeaderForDuplicateCheck() {
+        val s = nullableSeq(
+            listOf(null, ""),
+            listOf("1", "2"),
+        )
+
+        shouldThrow<MalformedCsvException> {
+            s.withNullableHeader().toList()
+        }
+    }
+
+    @Test
+    fun nullableHeader_autoRenameEmptyHeaderDuplicates() {
+        val result = nullableSeq(
+            listOf(null, null, "x"),
+            listOf("1", null, "3"),
+        ).withNullableHeader(autoRenameDuplicateHeaders = true).toList()
+
+        result.single() shouldBe linkedMapOf("" to "1", "_2" to null, "x" to "3")
+    }
+
+    @Test
+    fun nullableHeader_readNullableNullHeadersBecomeEmptyHeaders() {
+        val rows = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        ).readNullable(",\n1,".asSequence())
+
+        rows.withNullableHeader(autoRenameDuplicateHeaders = true).single() shouldBe
+            linkedMapOf("" to "1", "_2" to null)
     }
 }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderTest.kt
@@ -31,6 +31,11 @@ class CsvReaderTest {
     }
 
     @Test
+    fun readAllNullable_emptyInput() {
+        CsvReader().readAllNullable("") shouldBe emptyList()
+    }
+
+    @Test
     fun skipEmptyLine_false_keepsEmptyRows() {
         val reader = CsvReader(CsvReaderConfig(skipEmptyLine = false))
         reader.readAll("a\n\nb") shouldBe listOf(listOf("a"), listOf(""), listOf("b"))
@@ -143,6 +148,67 @@ class CsvReaderTest {
         val reader = CsvReader(CsvReaderConfig())
         val seq = reader.read("a,b,c\nd,e".asSequence())
         seq.take(1).toList() shouldBe listOf(listOf("a", "b", "c"))
+    }
+
+    @Test
+    fun readAllNullable_defaultKeepsEmptyStrings() {
+        val reader = CsvReader()
+        reader.readAllNullable("\"col1\",\"col2\"\n\"\",") shouldBe listOf(
+            listOf("col1", "col2"),
+            listOf("", ""),
+        )
+    }
+
+    @Test
+    fun readAllNullable_emptySeparators_issue81Sample() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readAllNullable("\"col1\",\"col2\"\n\"\",") shouldBe listOf(
+            listOf("col1", "col2"),
+            listOf("", null),
+        )
+    }
+
+    @Test
+    fun readAllNullable_emptyQuotes() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_QUOTES)
+        )
+        reader.readAllNullable("\"\",") shouldBe listOf(listOf(null, ""))
+    }
+
+    @Test
+    fun readAllNullable_bothEmptyKinds() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.BOTH)
+        )
+        reader.readAllNullable(",\"\"") shouldBe listOf(listOf(null, null))
+    }
+
+    @Test
+    fun readAllNullable_emptySeparators_leadingMiddleTrailingAndEof() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readAllNullable(",a,\nb,,") shouldBe listOf(
+            listOf(null, "a", null),
+            listOf("b", null, null),
+        )
+    }
+
+    @Test
+    fun readAllNullable_insufficientEmptyStringPaddingStaysEmptyString() {
+        val reader = CsvReader(
+            CsvReaderConfig(
+                insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.EMPTY_STRING,
+                nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS,
+            )
+        )
+        reader.readAllNullable("a,b,c\nd,e") shouldBe listOf(
+            listOf("a", "b", "c"),
+            listOf("d", "e", ""),
+        )
     }
 
     // --- Unquoted-field escape (issue #168) ---

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderTest.kt
@@ -211,6 +211,74 @@ class CsvReaderTest {
         )
     }
 
+    @Test
+    fun readAllNullable_skipEmptyLineTrue_dropsEmptyRows() {
+        val reader = CsvReader(CsvReaderConfig(skipEmptyLine = true))
+        reader.readAllNullable("a\n\nb") shouldBe listOf(listOf("a"), listOf("b"))
+    }
+
+    @Test
+    fun readAllNullable_insufficientErrorThrows() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        shouldThrow<CsvFieldNumDifferentException> {
+            reader.readAllNullable("a,b,c\nd,")
+        }
+    }
+
+    @Test
+    fun readAllNullable_insufficientIgnoreSkipsRow() {
+        val reader = CsvReader(
+            CsvReaderConfig(
+                insufficientFieldsRowBehaviour = InsufficientFieldsRowBehaviour.IGNORE,
+                nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS,
+            )
+        )
+        reader.readAllNullable("a,b,c\nd,\nf,g,h") shouldBe listOf(
+            listOf("a", "b", "c"),
+            listOf("f", "g", "h"),
+        )
+    }
+
+    @Test
+    fun readAllNullable_excessErrorThrows() {
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        shouldThrow<CsvFieldNumDifferentException> {
+            reader.readAllNullable("a,b\nc,,d")
+        }
+    }
+
+    @Test
+    fun readAllNullable_excessIgnoreSkipsRow() {
+        val reader = CsvReader(
+            CsvReaderConfig(
+                excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.IGNORE,
+                nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS,
+            )
+        )
+        reader.readAllNullable("a,b\nc,,d\ne,") shouldBe listOf(
+            listOf("a", "b"),
+            listOf("e", null),
+        )
+    }
+
+    @Test
+    fun readAllNullable_excessTrimTruncatesRow() {
+        val reader = CsvReader(
+            CsvReaderConfig(
+                excessFieldsRowBehaviour = ExcessFieldsRowBehaviour.TRIM,
+                nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS,
+            )
+        )
+        reader.readAllNullable("a,b\nc,,d") shouldBe listOf(
+            listOf("a", "b"),
+            listOf("c", null),
+        )
+    }
+
     // --- Unquoted-field escape (issue #168) ---
 
     private val explicitEscapeReader =

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoTest.kt
@@ -167,6 +167,15 @@ class ReaderIoTest {
     }
 
     @Test
+    fun readNullable_source_blockReturnValueIsPropagated() {
+        val source = FakeRawSource(csvBytes("\"\",,\n")).buffered()
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readNullable(source) { rows -> rows.single()[1] } shouldBe null
+    }
+
+    @Test
     fun readAllFromFile_stringPathOverloadIsCallable() {
         val reader = CsvReader()
         val callable: (String) -> List<List<String>> = { path -> reader.readAllFromFile(path) }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoTest.kt
@@ -158,9 +158,25 @@ class ReaderIoTest {
     }
 
     @Test
+    fun readAllNullable_source_usesNullFieldIndicator() {
+        val source = FakeRawSource(csvBytes("\"\",,\n")).buffered()
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readAllNullable(source) shouldBe listOf(listOf("", null, null))
+    }
+
+    @Test
     fun readAllFromFile_stringPathOverloadIsCallable() {
         val reader = CsvReader()
         val callable: (String) -> List<List<String>> = { path -> reader.readAllFromFile(path) }
+        callable shouldNotBe null
+    }
+
+    @Test
+    fun readAllNullableFromFile_stringPathOverloadIsCallable() {
+        val reader = CsvReader()
+        val callable: (String) -> List<List<String?>> = { path -> reader.readAllNullableFromFile(path) }
         callable shouldNotBe null
     }
 }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
@@ -69,6 +69,11 @@ class CsvWriterTest {
     }
 
     @Test
+    fun writeAllNullable_emptyRows() {
+        CsvWriter().writeAllNullable(emptyList()) shouldBe ""
+    }
+
+    @Test
     fun writeAll_emptyRow() {
         CsvWriter().writeAll(listOf(emptyList())) shouldBe "\r\n"
     }
@@ -114,6 +119,17 @@ class CsvWriterTest {
     fun writeAllNullable_quoteAllKeepsNullUnquotedAndQuotesEmptyString() {
         val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
         writer.writeAllNullable(listOf(listOf(null, "x", ""))) shouldBe ",\"x\",\"\"\r\n"
+    }
+
+    @Test
+    fun writeAllNullable_multiRow_outputLast_false() {
+        val writer = CsvWriter(
+            CsvWriterConfig(
+                outputLastLineTerminator = false,
+                quoteMode = WriteQuoteMode.ALL,
+            )
+        )
+        writer.writeAllNullable(listOf(listOf(null, ""), listOf("x", null))) shouldBe ",\"\"\r\n\"x\","
     }
 
     // -------- NON_NUMERIC quote --------

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
@@ -1,6 +1,9 @@
 package com.jsoizo.kotlincsv.writer
 
 import com.jsoizo.kotlincsv.CsvDialect
+import com.jsoizo.kotlincsv.reader.CsvNullFieldIndicator
+import com.jsoizo.kotlincsv.reader.CsvReader
+import com.jsoizo.kotlincsv.reader.CsvReaderConfig
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -61,6 +64,11 @@ class CsvWriterTest {
     }
 
     @Test
+    fun writeAllNullable_nullFieldsAreUnquotedEmptyFields() {
+        CsvWriter().writeAllNullable(listOf(listOf(null, "x", ""))) shouldBe ",x,\r\n"
+    }
+
+    @Test
     fun writeAll_emptyRow() {
         CsvWriter().writeAll(listOf(emptyList())) shouldBe "\r\n"
     }
@@ -100,6 +108,12 @@ class CsvWriterTest {
     fun quote_all_quotesEverything() {
         val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
         writer.writeAll(listOf(listOf("a", "b"))) shouldBe "\"a\",\"b\"\r\n"
+    }
+
+    @Test
+    fun writeAllNullable_quoteAllKeepsNullUnquotedAndQuotesEmptyString() {
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        writer.writeAllNullable(listOf(listOf(null, "x", ""))) shouldBe ",\"x\",\"\"\r\n"
     }
 
     // -------- NON_NUMERIC quote --------
@@ -221,5 +235,23 @@ class CsvWriterTest {
         val rows = generateSequence(0) { it + 1 }.map { listOf(it.toString()) }
         val partial = CsvWriter().write(rows).take(3).joinToString("")
         partial shouldBe "0\r\n"
+    }
+
+    @Test
+    fun writeNullable_returnsLazySequence() {
+        val rows = generateSequence(0) { it + 1 }.map { listOf<String?>(null, it.toString()) }
+        val partial = CsvWriter().writeNullable(rows).take(4).joinToString("")
+        partial shouldBe ",0\r\n"
+    }
+
+    @Test
+    fun nullableRoundTrip_quoteAllDistinguishesNullAndEmptyString() {
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        val rows = listOf(listOf(null, "", "x"))
+
+        reader.readAllNullable(writer.writeAllNullable(rows)) shouldBe rows
     }
 }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterTest.kt
@@ -261,6 +261,17 @@ class CsvWriterTest {
     }
 
     @Test
+    fun writeNullable_emptyRowsReturnsEmptySequence() {
+        CsvWriter().writeNullable(emptySequence()).toList() shouldBe emptyList()
+    }
+
+    @Test
+    fun writeNullable_multiRow_outputLast_true() {
+        val rows = sequenceOf(listOf<String?>(null), listOf("x"))
+        CsvWriter().writeNullable(rows).joinToString("") shouldBe "\r\nx\r\n"
+    }
+
+    @Test
     fun nullableRoundTrip_quoteAllDistinguishesNullAndEmptyString() {
         val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
         val reader = CsvReader(

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
@@ -44,6 +44,34 @@ class WriterIoTest {
     }
 
     @Test
+    fun writeNullable_sink_listInputMatchesSequenceOutput() {
+        val rows = listOf(listOf<String?>(null, "b"), listOf("", null))
+        val rawList = FakeRawSink()
+        rawList.buffered().use { sink ->
+            CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL)).writeNullable(rows, sink)
+        }
+
+        val rawSeq = FakeRawSink()
+        rawSeq.buffered().use { sink ->
+            CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL)).writeNullable(rows.asSequence(), sink)
+        }
+
+        rawList.snapshot().toList() shouldBe rawSeq.snapshot().toList()
+    }
+
+    @Test
+    fun writeNullable_sink_prependBomEmitsBomThenBody() {
+        val rows = listOf(listOf<String?>(null, "b"))
+        val raw = FakeRawSink()
+        raw.buffered().use { sink ->
+            CsvWriter().writeNullable(rows, sink, CsvWriteIoOptions(prependBom = true))
+        }
+        val out = raw.snapshot()
+        out.copyOfRange(0, 3).toList() shouldBe bom.toList()
+        out.copyOfRange(3, out.size).decodeToString() shouldBe ",b\r\n"
+    }
+
+    @Test
     fun write_sink_prependBomEmitsBomThenBody() {
         val rows = listOf(listOf("a", "b"))
         val raw = FakeRawSink()
@@ -74,6 +102,15 @@ class WriterIoTest {
         val raw = FakeRawSink()
         raw.buffered().use { sink ->
             CsvWriter().write(emptySequence(), sink)
+        }
+        raw.snapshot().size shouldBe 0
+    }
+
+    @Test
+    fun writeNullable_sink_emptyRowsProducesEmptyOutput() {
+        val raw = FakeRawSink()
+        raw.buffered().use { sink ->
+            CsvWriter().writeNullable(emptySequence(), sink)
         }
         raw.snapshot().size shouldBe 0
     }

--- a/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
+++ b/src/commonTest/kotlin/com/jsoizo/kotlincsv/writer/WriterIoTest.kt
@@ -34,6 +34,16 @@ class WriterIoTest {
     }
 
     @Test
+    fun writeNullable_sink_sequenceInputProducesEncodedBytes() {
+        val rows = sequenceOf(listOf<String?>(null, "b"), listOf("", null))
+        val raw = FakeRawSink()
+        raw.buffered().use { sink ->
+            CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL)).writeNullable(rows, sink)
+        }
+        raw.snapshot().decodeToString() shouldBe ",\"b\"\r\n\"\",\r\n"
+    }
+
+    @Test
     fun write_sink_prependBomEmitsBomThenBody() {
         val rows = listOf(listOf("a", "b"))
         val raw = FakeRawSink()
@@ -105,6 +115,18 @@ class WriterIoTest {
         }
         val callableList: (String) -> Unit = { path ->
             writer.writeToFile(listOf(listOf("a")), path)
+        }
+        (callableSeq to callableList) shouldBe (callableSeq to callableList)
+    }
+
+    @Test
+    fun writeNullableToFile_stringPathOverloadIsCallable() {
+        val writer = CsvWriter()
+        val callableSeq: (String) -> Unit = { path ->
+            writer.writeNullableToFile(sequenceOf(listOf<String?>(null, "a")), path)
+        }
+        val callableList: (String) -> Unit = { path ->
+            writer.writeNullableToFile(listOf(listOf<String?>(null, "a")), path)
         }
         (callableSeq to callableList) shouldBe (callableSeq to callableList)
     }

--- a/src/jvmMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoJvm.kt
+++ b/src/jvmMain/kotlin/com/jsoizo/kotlincsv/reader/ReaderIoJvm.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.reader
 
 import com.jsoizo.kotlincsv.reader.internal.parseRowsFromChunks
+import com.jsoizo.kotlincsv.reader.internal.parseRowsWithMetadataFromChunks
 import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -28,6 +29,23 @@ fun CsvReader.readAllFromFile(
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = readFromFile(file, charset, options) { it.toList() }
 
+/** Read nullable CSV rows from [file] decoded with [charset]. */
+fun <T> CsvReader.readNullableFromFile(
+    file: File,
+    charset: String = "UTF-8",
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+    block: (Sequence<List<String?>>) -> T,
+): T = file.inputStream().use { stream ->
+    readNullable(stream, charset, options, block)
+}
+
+/** Eagerly read all nullable CSV rows from [file] decoded with [charset]. */
+fun CsvReader.readAllNullableFromFile(
+    file: File,
+    charset: String = "UTF-8",
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+): List<List<String?>> = readNullableFromFile(file, charset, options) { it.toList() }
+
 /**
  * Read CSV rows from [stream] decoded with [charset] and pass them to
  * [block]. [stream] is caller-owned — this overload does not close it.
@@ -53,6 +71,28 @@ fun CsvReader.readAll(
     charset: String = "UTF-8",
     options: CsvReadIoOptions = CsvReadIoOptions(),
 ): List<List<String>> = read(stream, charset, options) { it.toList() }
+
+/**
+ * Read nullable CSV rows from [stream] decoded with [charset].
+ * [stream] is caller-owned and is not closed by this call.
+ */
+fun <T> CsvReader.readNullable(
+    stream: InputStream,
+    charset: String = "UTF-8",
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+    block: (Sequence<List<String?>>) -> T,
+): T {
+    val reader = InputStreamReader(stream, Charset.forName(charset)).buffered()
+    val parsed = parseRowsWithMetadataFromChunks(reader.asChunkReader(), config.dialect, options.stripBom)
+    return block(applyNullablePipeline(parsed))
+}
+
+/** Eagerly read all nullable CSV rows from [stream] decoded with [charset]. */
+fun CsvReader.readAllNullable(
+    stream: InputStream,
+    charset: String = "UTF-8",
+    options: CsvReadIoOptions = CsvReadIoOptions(),
+): List<List<String?>> = readNullable(stream, charset, options) { it.toList() }
 
 private fun Reader.asChunkReader(): (CharArray) -> Int = { buffer ->
     val charsRead = read(buffer)

--- a/src/jvmMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIoJvm.kt
+++ b/src/jvmMain/kotlin/com/jsoizo/kotlincsv/writer/WriterIoJvm.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.writer
 
 import com.jsoizo.kotlincsv.writer.internal.appendRows
+import com.jsoizo.kotlincsv.writer.internal.appendNullableRows
 import java.io.BufferedWriter
 import java.io.File
 import java.io.OutputStream
@@ -25,6 +26,21 @@ fun CsvWriter.writeToFile(
 }
 
 /**
+ * Encode nullable [rows] and write to [file] using [charset]. Null fields are
+ * emitted as unquoted empty fields.
+ */
+fun CsvWriter.writeNullableToFile(
+    rows: Sequence<List<String?>>,
+    file: File,
+    charset: String = "UTF-8",
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) {
+    file.outputStream().use { stream ->
+        writeNullable(rows, stream, charset, options)
+    }
+}
+
+/**
  * Encode [rows] and write to [stream] using [charset]. [stream] is
  * caller-owned and is flushed but not closed by this call.
  */
@@ -39,6 +55,24 @@ fun CsvWriter.write(
         writer.write(BOM_STRING)
     }
     appendRows(rows, config, writer)
+    writer.flush()
+}
+
+/**
+ * Encode nullable [rows] and write to [stream] using [charset]. [stream] is
+ * caller-owned and is flushed but not closed by this call.
+ */
+fun CsvWriter.writeNullable(
+    rows: Sequence<List<String?>>,
+    stream: OutputStream,
+    charset: String = "UTF-8",
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) {
+    val writer = BufferedWriter(OutputStreamWriter(stream, Charset.forName(charset)))
+    if (options.prependBom) {
+        writer.write(BOM_STRING)
+    }
+    appendNullableRows(rows, config, writer)
     writer.flush()
 }
 
@@ -57,3 +91,19 @@ fun CsvWriter.write(
     charset: String = "UTF-8",
     options: CsvWriteIoOptions = CsvWriteIoOptions(),
 ) = write(rows.asSequence(), stream, charset, options)
+
+/** @see writeNullableToFile */
+fun CsvWriter.writeNullableToFile(
+    rows: List<List<String?>>,
+    file: File,
+    charset: String = "UTF-8",
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullableToFile(rows.asSequence(), file, charset, options)
+
+/** @see writeNullable */
+fun CsvWriter.writeNullable(
+    rows: List<List<String?>>,
+    stream: OutputStream,
+    charset: String = "UTF-8",
+    options: CsvWriteIoOptions = CsvWriteIoOptions(),
+) = writeNullable(rows.asSequence(), stream, charset, options)

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
@@ -14,6 +14,8 @@ class CsvReaderJvmIoTest {
 
     private val sampleCsv = "a,b,c\nd,e,f"
     private val sampleRows = listOf(listOf("a", "b", "c"), listOf("d", "e", "f"))
+    private val nullableCsv = "\"empty\",\"null\"\n\"\",\n"
+    private val nullableRows = listOf(listOf("empty", "null"), listOf("", null))
 
     @Test
     fun readFromFile_file_utf8_basic_decodesRows() {
@@ -152,10 +154,35 @@ class CsvReaderJvmIoTest {
     }
 
     @Test
+    fun readAllNullableFromFile_file_utf8_decodesNullFields() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-reader-nullable", ".csv")
+        try {
+            Files.writeString(tmp, nullableCsv, Charsets.UTF_8)
+            val reader = CsvReader(
+                CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+            )
+            reader.readAllNullableFromFile(tmp.toFile()) shouldBe nullableRows
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun readAll_stream_utf8_basic_decodesRowsAndDoesNotCloseCallerStream() {
         val raw = sampleCsv.toByteArray(Charsets.UTF_8)
         val counting = CountingInputStream(ByteArrayInputStream(raw))
         CsvReader().readAll(counting) shouldBe sampleRows
+        counting.closeCount shouldBe 0
+    }
+
+    @Test
+    fun readAllNullable_stream_utf8_decodesNullFieldsAndDoesNotCloseCallerStream() {
+        val raw = nullableCsv.toByteArray(Charsets.UTF_8)
+        val counting = CountingInputStream(ByteArrayInputStream(raw))
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readAllNullable(counting) shouldBe nullableRows
         counting.closeCount shouldBe 0
     }
 

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
@@ -168,6 +168,24 @@ class CsvReaderJvmIoTest {
     }
 
     @Test
+    fun readNullableFromFile_file_explicitOptionsDecodesNullFields() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-reader-nullable-options", ".csv")
+        try {
+            Files.writeString(tmp, nullableCsv, Charsets.UTF_8)
+            val reader = CsvReader(
+                CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+            )
+            reader.readNullableFromFile(
+                tmp.toFile(),
+                charset = "UTF-8",
+                options = CsvReadIoOptions(stripBom = true),
+            ) { rows -> rows.toList() } shouldBe nullableRows
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun readAll_stream_utf8_basic_decodesRowsAndDoesNotCloseCallerStream() {
         val raw = sampleCsv.toByteArray(Charsets.UTF_8)
         val counting = CountingInputStream(ByteArrayInputStream(raw))
@@ -183,6 +201,21 @@ class CsvReaderJvmIoTest {
             CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
         )
         reader.readAllNullable(counting) shouldBe nullableRows
+        counting.closeCount shouldBe 0
+    }
+
+    @Test
+    fun readNullable_stream_explicitOptionsDecodesNullFieldsAndDoesNotCloseCallerStream() {
+        val raw = nullableCsv.toByteArray(Charsets.UTF_8)
+        val counting = CountingInputStream(ByteArrayInputStream(raw))
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readNullable(
+            counting,
+            charset = "UTF-8",
+            options = CsvReadIoOptions(stripBom = true),
+        ) { rows -> rows.toList() } shouldBe nullableRows
         counting.closeCount shouldBe 0
     }
 

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderJvmIoTest.kt
@@ -186,6 +186,20 @@ class CsvReaderJvmIoTest {
     }
 
     @Test
+    fun readNullableFromFile_file_defaultOptionsPropagatesBlockReturnValue() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-reader-nullable-defaults", ".csv")
+        try {
+            Files.writeString(tmp, nullableCsv, Charsets.UTF_8)
+            val reader = CsvReader(
+                CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+            )
+            reader.readNullableFromFile(tmp.toFile()) { rows -> rows.drop(1).first() } shouldBe listOf("", null)
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun readAll_stream_utf8_basic_decodesRowsAndDoesNotCloseCallerStream() {
         val raw = sampleCsv.toByteArray(Charsets.UTF_8)
         val counting = CountingInputStream(ByteArrayInputStream(raw))
@@ -201,6 +215,17 @@ class CsvReaderJvmIoTest {
             CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
         )
         reader.readAllNullable(counting) shouldBe nullableRows
+        counting.closeCount shouldBe 0
+    }
+
+    @Test
+    fun readNullable_stream_defaultOptionsDecodesNullFieldsAndDoesNotCloseCallerStream() {
+        val raw = nullableCsv.toByteArray(Charsets.UTF_8)
+        val counting = CountingInputStream(ByteArrayInputStream(raw))
+        val reader = CsvReader(
+            CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+        )
+        reader.readNullable(counting) { rows -> rows.toList() } shouldBe nullableRows
         counting.closeCount shouldBe 0
     }
 

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
@@ -39,6 +39,24 @@ class CsvReaderPathSmokeTest {
     }
 
     @Test
+    fun readNullableFromFile_kotlinxIoPath_readsNullFieldsFromRealTempFile() {
+        val tmp = Files.createTempFile("kotlin-csv-reader-smoke-nullable-path", ".csv")
+        try {
+            Files.writeString(tmp, "\"empty\",\"null\"\n\"\",\n")
+            val reader = CsvReader(
+                CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+            )
+            val path = KxPath(tmp.toString())
+            reader.readNullableFromFile(path) { rows -> rows.toList() } shouldBe
+                listOf(listOf("empty", "null"), listOf("", null))
+            reader.readAllNullableFromFile(path) shouldBe
+                listOf(listOf("empty", "null"), listOf("", null))
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun readFromFile_kotlinxIoPath_defaultOptions_decodesRows() {
         // Direct call into the kotlinx-io Path overloads with options omitted,
         // covering the default-argument synthetic methods on readFromFile and

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
@@ -33,6 +33,8 @@ class CsvReaderPathSmokeTest {
             )
             reader.readAllNullableFromFile(tmp.toString()) shouldBe
                 listOf(listOf("empty", "null"), listOf("", null))
+            reader.readNullableFromFile(tmp.toString()) { rows -> rows.drop(1).first() } shouldBe
+                listOf("", null)
         } finally {
             tmp.deleteIfExists()
         }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/reader/CsvReaderPathSmokeTest.kt
@@ -24,6 +24,21 @@ class CsvReaderPathSmokeTest {
     }
 
     @Test
+    fun readAllNullableFromFile_stringPath_readsNullFieldsFromRealTempFile() {
+        val tmp = Files.createTempFile("kotlin-csv-reader-smoke-nullable", ".csv")
+        try {
+            Files.writeString(tmp, "\"empty\",\"null\"\n\"\",\n")
+            val reader = CsvReader(
+                CsvReaderConfig(nullFieldIndicator = CsvNullFieldIndicator.EMPTY_SEPARATORS)
+            )
+            reader.readAllNullableFromFile(tmp.toString()) shouldBe
+                listOf(listOf("empty", "null"), listOf("", null))
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun readFromFile_kotlinxIoPath_defaultOptions_decodesRows() {
         // Direct call into the kotlinx-io Path overloads with options omitted,
         // covering the default-argument synthetic methods on readFromFile and

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
@@ -16,6 +16,8 @@ class CsvWriterJvmIoTest {
         listOf("d", "e", "f"),
     )
     private val sampleRowsEncoded = "a,b,c\r\nd,e,f\r\n"
+    private val nullableRows = listOf(listOf<String?>(null, "", "x"))
+    private val nullableRowsEncoded = ",\"\",\"x\"\r\n"
 
     @Test
     fun writeToFile_file_utf8_basic_writesEncodedBytes() {
@@ -53,6 +55,18 @@ class CsvWriterJvmIoTest {
     }
 
     @Test
+    fun writeNullableToFile_file_utf8_writesNullFields() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-writer-nullable", ".csv")
+        try {
+            val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+            writer.writeNullableToFile(nullableRows, tmp.toFile())
+            Files.readString(tmp, Charsets.UTF_8) shouldBe nullableRowsEncoded
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun write_stream_callerOwnedStream_isNeitherClosedNorImplicitlyMutated() {
         val raw = ByteArrayOutputStream()
         val counting = CountingOutputStream(raw)
@@ -60,6 +74,17 @@ class CsvWriterJvmIoTest {
         raw.toByteArray().toString(Charsets.UTF_8) shouldBe sampleRowsEncoded
         // Caller owns the stream — overload must not close it.
         counting.closeCount shouldBe 0
+    }
+
+    @Test
+    fun writeNullable_stream_callerOwnedStream_encodesNullFieldsAndDoesNotClose() {
+        val raw = ByteArrayOutputStream()
+        val counting = CountingOutputStream(raw)
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        writer.writeNullable(nullableRows, counting)
+        raw.toByteArray().toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
+        counting.closeCount shouldBe 0
+        counting.flushCount shouldBeGreaterThanOrEqual 1
     }
 
     @Test

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
@@ -67,6 +67,23 @@ class CsvWriterJvmIoTest {
     }
 
     @Test
+    fun writeNullableToFile_file_sequenceInputWithExplicitOptions_writesNullFields() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-writer-nullable-sequence", ".csv")
+        try {
+            val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+            writer.writeNullableToFile(
+                nullableRows.asSequence(),
+                tmp.toFile(),
+                charset = "UTF-8",
+                options = CsvWriteIoOptions(prependBom = false),
+            )
+            Files.readString(tmp, Charsets.UTF_8) shouldBe nullableRowsEncoded
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun write_stream_callerOwnedStream_isNeitherClosedNorImplicitlyMutated() {
         val raw = ByteArrayOutputStream()
         val counting = CountingOutputStream(raw)
@@ -85,6 +102,21 @@ class CsvWriterJvmIoTest {
         raw.toByteArray().toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
         counting.closeCount shouldBe 0
         counting.flushCount shouldBeGreaterThanOrEqual 1
+    }
+
+    @Test
+    fun writeNullable_stream_sequenceInputWithExplicitOptions_encodesNullFieldsAndDoesNotClose() {
+        val raw = ByteArrayOutputStream()
+        val counting = CountingOutputStream(raw)
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        writer.writeNullable(
+            nullableRows.asSequence(),
+            counting,
+            charset = "UTF-8",
+            options = CsvWriteIoOptions(prependBom = false),
+        )
+        raw.toByteArray().toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
+        counting.closeCount shouldBe 0
     }
 
     @Test

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
@@ -109,6 +109,17 @@ class CsvWriterJvmIoTest {
     }
 
     @Test
+    fun writeNullable_stream_prependBomUtf8_emitsEfBbBfPrefix() {
+        val raw = ByteArrayOutputStream()
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        writer.writeNullable(nullableRows, raw, options = CsvWriteIoOptions(prependBom = true))
+        val out = raw.toByteArray()
+        out.copyOfRange(0, 3).toList() shouldBe
+            listOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        out.copyOfRange(3, out.size).toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
+    }
+
+    @Test
     fun write_stream_prependBomShiftJis_emitsEncoderSubstitution() {
         // Shift_JIS has no BOM concept; Java's default unmappable-character
         // policy substitutes U+FEFF with `?` (0x3F). Pin this behaviour so a

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterJvmIoTest.kt
@@ -84,6 +84,18 @@ class CsvWriterJvmIoTest {
     }
 
     @Test
+    fun writeNullableToFile_file_sequenceInputWithDefaultOptions_writesNullFields() {
+        val tmp = Files.createTempFile("kotlin-csv-jvm-writer-nullable-sequence-defaults", ".csv")
+        try {
+            val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+            writer.writeNullableToFile(nullableRows.asSequence(), tmp.toFile())
+            Files.readString(tmp, Charsets.UTF_8) shouldBe nullableRowsEncoded
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
     fun write_stream_callerOwnedStream_isNeitherClosedNorImplicitlyMutated() {
         val raw = ByteArrayOutputStream()
         val counting = CountingOutputStream(raw)
@@ -115,6 +127,16 @@ class CsvWriterJvmIoTest {
             charset = "UTF-8",
             options = CsvWriteIoOptions(prependBom = false),
         )
+        raw.toByteArray().toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
+        counting.closeCount shouldBe 0
+    }
+
+    @Test
+    fun writeNullable_stream_sequenceInputWithDefaultOptions_encodesNullFieldsAndDoesNotClose() {
+        val raw = ByteArrayOutputStream()
+        val counting = CountingOutputStream(raw)
+        val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+        writer.writeNullable(nullableRows.asSequence(), counting)
         raw.toByteArray().toString(Charsets.UTF_8) shouldBe nullableRowsEncoded
         counting.closeCount shouldBe 0
     }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
@@ -29,6 +29,9 @@ class CsvWriterPathSmokeTest {
             val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
             writer.writeNullableToFile(listOf(listOf<String?>(null, "", "x")), tmp.toString())
             Files.readString(tmp) shouldBe ",\"\",\"x\"\r\n"
+
+            writer.writeNullableToFile(sequenceOf(listOf<String?>(null, "y")), tmp.toString())
+            Files.readString(tmp) shouldBe ",\"y\"\r\n"
         } finally {
             tmp.deleteIfExists()
         }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
@@ -20,4 +20,16 @@ class CsvWriterPathSmokeTest {
             tmp.deleteIfExists()
         }
     }
+
+    @Test
+    fun writeNullableToFile_stringPath_writesNullFieldsToRealTempFile() {
+        val tmp = Files.createTempFile("kotlin-csv-writer-smoke-nullable", ".csv")
+        try {
+            val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+            writer.writeNullableToFile(listOf(listOf<String?>(null, "", "x")), tmp.toString())
+            Files.readString(tmp) shouldBe ",\"\",\"x\"\r\n"
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
 }

--- a/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
+++ b/src/jvmTest/kotlin/com/jsoizo/kotlincsv/writer/CsvWriterPathSmokeTest.kt
@@ -1,6 +1,7 @@
 package com.jsoizo.kotlincsv.writer
 
 import io.kotest.matchers.shouldBe
+import kotlinx.io.files.Path as KxPath
 import java.nio.file.Files
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
@@ -28,6 +29,22 @@ class CsvWriterPathSmokeTest {
             val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
             writer.writeNullableToFile(listOf(listOf<String?>(null, "", "x")), tmp.toString())
             Files.readString(tmp) shouldBe ",\"\",\"x\"\r\n"
+        } finally {
+            tmp.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun writeNullableToFile_kotlinxIoPath_writesNullFieldsToRealTempFile() {
+        val tmp = Files.createTempFile("kotlin-csv-writer-smoke-nullable-path", ".csv")
+        try {
+            val writer = CsvWriter(CsvWriterConfig(quoteMode = WriteQuoteMode.ALL))
+            val path = KxPath(tmp.toString())
+            writer.writeNullableToFile(sequenceOf(listOf<String?>(null, "", "x")), path)
+            Files.readString(tmp) shouldBe ",\"\",\"x\"\r\n"
+
+            writer.writeNullableToFile(listOf(listOf<String?>(null, "y")), path)
+            Files.readString(tmp) shouldBe ",\"y\"\r\n"
         } finally {
             tmp.deleteIfExists()
         }


### PR DESCRIPTION
## Summary
- Add nullable reader APIs with `CsvNullFieldIndicator` to distinguish quoted empty strings from unquoted empty fields.
- Add nullable header and I/O overloads so header-based reads can return `Map<String, String?>` values.
- Add nullable writer APIs that emit `null` as unquoted empty fields, plus README and module documentation.

## Verification
- `./gradlew check`

Closes #81
